### PR TITLE
Remove obsolete UrlHelper

### DIFF
--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -1,8 +1,0 @@
-module UrlHelper
-  include Blacklight::UrlHelperBehavior
-
-  def url_for_document(doc, options = {})
-    return "" if !doc
-    "/" + params[:controller] + "/" + doc.to_param
-  end
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,12 +76,6 @@ Rails.application.routes.draw do
   #  ActiveAdmin.routes(self)
   #end 
   
-  get "/manuscripts", to: redirect('/sources')
-  get "/manuscripts/:name", to: redirect('/sources/%{name}')
-
-  get "/sources", to: redirect('/catalog')
-  get "/sources/:name", to: redirect('/catalog/%{name}')
-
   ## Set up routes to redirect legacy /pages from muscat2
   ## to the new site URL
   get '/pages', to: redirect(RISM::LEGACY_PAGES_URL)


### PR DESCRIPTION
Current behaviour of UrlHelper creates a innecessary redirect from /sources
to /catalog, probably for some old requirement no longer valid.  Remove
local UrlHelper and inherit generic Blacklight behaviour (by default,
/catalog) and the second part of those redirects in routes.rb.