### PR TITLE
Change local variable name composer to full_name

### DIFF
--- a/lib/marc_person.rb
+++ b/lib/marc_person.rb
@@ -4,14 +4,14 @@ class MarcPerson < Marc
   end
 
   def get_full_name_and_dates
-    composer = ""
-    composer_d = ""
+    full_name = ""
+    full_name_d = ""
     dates = nil
 
     if node = first_occurance("100", "a")
       if node.content
-        composer = node.content.truncate(128)
-        composer_d = node.content.downcase.truncate(128)
+        full_name = node.content.truncate(128)
+        full_name_d = node.content.downcase.truncate(128)
       end
     end
     
@@ -21,7 +21,7 @@ class MarcPerson < Marc
       end
     end
     
-    [composer, composer_d, dates]
+    [full_name, full_name_d, dates]
   end
   
   def get_alternate_names_and_dates


### PR DESCRIPTION
The MarcPerson class is used both for sources and publications.  The
composer and composer_d variables are certainly local, and this change is
mostly useless, except that it now matches the function name, clarifies its
use and helps contributors familiarisating with Muscat code that it generic,
not only for musical sources.