### PR TITLE
Add record_type do publications

### DIFF
--- a/db/migrate/20210514040721_add_record_type_to_publications.rb
+++ b/db/migrate/20210514040721_add_record_type_to_publications.rb
@@ -1,0 +1,6 @@
+class AddRecordTypeToPublications < ActiveRecord::Migration[5.2]
+  def change
+    add_column :publications, :record_type, :integer, limit: 1, default: 0
+    add_index :publications, :record_type
+  end
+end


### PR DESCRIPTION
Add the same field as in sources, as it will be needed as we will create
different templates.  Please note that:

1.  At this moment there is yet no use for this field.  This will come
later.
2.  I haven't attached the db/schema.rb file in this patch due to a
conflict.  This is my first migration and I'm unsure how to proceed, but
fortunately db/schema.rb is (re)generated automatically after performing
'rails db:migrate', so please do this step for me.  Thanks.