### PR TITLE
Create indexes for created_at and updated_at in publications

### DIFF
--- a/db/migrate/20210514043225_add_index_to_publications.rb
+++ b/db/migrate/20210514043225_add_index_to_publications.rb
@@ -1,0 +1,6 @@
+class AddIndexToPublications < ActiveRecord::Migration[5.2]
+  def change
+    add_index :publications, :created_at
+    add_index :publications, :updated_at
+  end
+end


### PR DESCRIPTION
Create the same indexes as in sources, as it is needed for fast date
searching.

Please note that I haven't attached the db/schema.rb file in this patch due
to a conflict and and I'm unsure how to proceed, but fortunately
db/schema.rb is (re)generated automatically after performing 'rails
db:migrate', so please do this step for me.  Thanks.