### PR TITLE
New global config variable: MAIN_BIBLIOGRAPHIC_RECORD_TYPE

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -179,7 +179,7 @@ class CatalogController < ApplicationController
       :"q.alt" => "*:*",
       :rows => 20,
       :defType => 'edismax',
-      :fq => "+type:#{RISM::MAIN_BIBLIOGRAPHIC_RECORD_TYPE} wf_stage_s:published",
+      :fq => "+type:#{RISM::MAIN_BIBLIOGRAPHIC_RECORD_TYPE} +wf_stage_s:published",
       :hl => 'false',
       :"hl.simple.pre" => '<span class="highlight">',
       :"hl.simple.post" => "</span>",

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -118,7 +118,7 @@ class CatalogController < ApplicationController
     if params[:id].start_with?('00000')
       params[:id] = params[:id][5, params[:id].length]
     end
-    params[:id] = "Source " + params[:id]
+    params[:id] = "#{RISM::MAIN_BIBLIOGRAPHIC_RECORD_TYPE} #{params[:id]}"
   end
 
   def mei
@@ -179,7 +179,7 @@ class CatalogController < ApplicationController
       :"q.alt" => "*:*",
       :rows => 20,
       :defType => 'edismax',
-      :fq => "+type:Source +wf_stage_s:published",
+      :fq => "+type:#{RISM::MAIN_BIBLIOGRAPHIC_RECORD_TYPE} wf_stage_s:published",
       :hl => 'false',
       :"hl.simple.pre" => '<span class="highlight">',
       :"hl.simple.post" => "</span>",

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -4,12 +4,17 @@
   This is pretty hackish for now - figure out a better way to do this into the CatalogController! -%>
 
 <%
-	@item = Source.find(@document.id.split(" ")[1]) # hackady-hack! Source 1234567 -> 1234567
+	if RISM::MAIN_BIBLIOGRAPHIC_RECORD_TYPE == "Source"
+	  # hackady-hack! Source 1234567 -> 1234567
+	  @item = Source.find(@document.id.split[1])
+	else
+	  @item = Publication.find(@document.id.split[1])
+	end
 	@editor_profile = EditorConfiguration.get_show_layout @item
 %>
 <dl class="dl-horizontal  dl-invert">
 	<%= render :partial => "marc/show", :locals => { :opac => true } %>
-	<%- if @item.digital_objects.size > 0 %>
+	<%- if @item.has_attribute?(:digital_objects) && @item.digital_objects.size > 0 %>
 		<%= render :partial => "catalog/digital_objects" %>
 	<%- end %>
 </dl>

--- a/config/sample_application.rb
+++ b/config/sample_application.rb
@@ -73,9 +73,21 @@ module RISM
   # search pages (served by Blacklight, that is, /catalog)
   ROOT_REDIRECT = "/catalog"
 
+  # Muscat has two bibliographic record types: Source and Publication.
+  # Source is for unique copies found in libraries, archives or
+  # museums, and strongly tied to musical manuscripts (ex., 100 tag is
+  # named Composer); Publication can describe any bibliographic work,
+  # and the default templates are oriented to describe academic,
+  # research or secondary literature works.  If you will to use Muscat
+  # as originally intended, keep "Source".  If you want to use it as
+  # institutional or research repository, choose "Publication".
+  # Please note that that this second choice is an ongoing work and is
+  # not finished yet.
+  MAIN_BIBLIOGRAPHIC_RECORD_TYPE = "Source"
+
   # Record ids for each records type
   BASE_NEW_IDS = {
-    :publication        => 0,
+    :publication      => 0,
     :holding          => 0,
     :institution      => 0,
     :liturgical_feast => 0,


### PR DESCRIPTION
Muscat was created for cataloguing musical manuscripts (Sources), but it
also allows cataloguing secondary literature (Publications).  There is some
work going on to adapt Muscat to be used as institutional or research
repository, where the main bibliographic record type would be Publications.
This first patch allows to define this parameter, and just corrects the
public, Blacklight Solr interface.