### PR TITLE
Fix crontab instructions

### DIFF
--- a/2- INSTALL.rdoc
+++ b/2- INSTALL.rdoc
@@ -260,20 +260,26 @@ Also make sure that if there is a proxy, it is configured in `config/initializer
 
 === Crontab installation
 
-In version 7.0 the crono scheduler was removed and a normal crontab plus a script is provided. The default crontab file should be linked in /etc/conn.d. Edit the muscat_crontab to set PATH_TO to the correct muscat installation, you will need to do it by hand.
+In version 7.0 the crono scheduler was removed and a normal crontab plus a script is provided.
 
-On debian/ubuntu this should work:
+To edit your crontab table, become the user where you execute Muscat (via sudo or su www-data, or normal user if you prefer the apache-itk option), and from the shell, execute:
 
- ln -s config/muscat_crontab /etc/cron.d
- chmod +x /etc/cron/muscat_crontab
- sudo service cron restart
+ crontab -e
+
+That will open your $EDITOR and then paste the contents of the sample crontab file provided as config/muscat_crontab.  After saving the file, crontab will check your syntax and give you hints if it finds errors.
 
 If your crontab still has this line:
 
  0 2 * * * cd $PATH_TO && $PATH_TO/bin/rake blacklight:delete_old_searches[7] RAILS_ENV=production
 
-It is save to delete it as it is now taken care but the global muscat crontab.
-*NOTE* If you ever change the cron file name, it CANNOT contains dots! Or it will silently fail.
+It is safe to delete it, as it is now taken care but the global muscat crontab.  To review your table, execute:
+
+ crontab -l
+
+Please take extra care not to execute crontab without any parameter, because then it expects input from the terminal and removes previous contents.
+
+If you execute multiple instances of Muscat in the same server, being real or virtual, via apache-itk or virtual machine, please take care of not executing them at the same hour or day of the week.
+
 
 == Some MySQL optimizations
 

--- a/config/muscat_crontab
+++ b/config/muscat_crontab
@@ -1,12 +1,3 @@
-# Crontab for Muscat
-# Please copy in /etc/cron.d/
-# NOTE since cron is brain dead, this file name MUST NOT contain a dot '.'
-# or cron will not execute it and say nothing. It is documented crazyness
-# as usual so thanks for this crazyness
-SHELL=/bin/sh
-PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-
-# NOTE
 # PLEASE SET THE CORRECT PATH_TO
 
 # Example of job definition:
@@ -16,16 +7,16 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 # |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
 # |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
 # |  |  |  |  |
-# *  *  *  *  * user-name command to be executed
+# *  *  *  *  * command to be executed
 
-00  08  *  *  sun www-data PATH_TO/muscat/bin/muscat_execute_job ModificationDigestJob production :weekly
-00  20  *  *  *   www-data PATH_TO/muscat/bin/muscat_execute_job ModificationDigestJob production :daily
+00  08  *  *  sun PATH_TO/muscat/bin/muscat_execute_job ModificationDigestJob production :weekly
+00  20  *  *  *   PATH_TO/muscat/bin/muscat_execute_job ModificationDigestJob production :daily
 
 # Cleanup jobs
-00  01  *  *  *   www-data PATH_TO/muscat/bin/muscat_execute_job PurgeSearchesJob production
-00  03  *  *  *   www-data PATH_TO/muscat/bin/muscat_execute_job PurgeFolderItemsJob production
-00  05  *  *  *   www-data PATH_TO/muscat/bin/muscat_execute_job ExportCleanupJob production
+00  01  *  *  *   PATH_TO/muscat/bin/muscat_execute_job PurgeSearchesJob production
+00  03  *  *  *   PATH_TO/muscat/bin/muscat_execute_job PurgeFolderItemsJob production
+00  05  *  *  *   PATH_TO/muscat/bin/muscat_execute_job ExportCleanupJob production
 
 # Maintenance and weekly report
-00  04  *  *  sun www-data PATH_TO/muscat/bin/muscat_execute_job MuscatMaintenanceJob production
-00  07  *  *  sun www-data PATH_TO/muscat/bin/muscat_execute_job MuscatCheckupReportJob production
+00  04  *  *  sun PATH_TO/muscat/bin/muscat_execute_job MuscatMaintenanceJob production
+00  07  *  *  sun PATH_TO/muscat/bin/muscat_execute_job MuscatCheckupReportJob production


### PR DESCRIPTION
Current crontab installation instructions are not following the standard
crontab command procedures.  Adapt them to conventional use.