### PR TITLE
Update labels for co-composer

### DIFF
--- a/config/editor_profiles/default/configurations/HoldingBasicLabels.yml
+++ b/config/editor_profiles/default/configurations/HoldingBasicLabels.yml
@@ -226,7 +226,7 @@ com:
 cst:
   label: records.costume_designer
 ctb:
-  label: records.co-composer
+  label: records.co_composer
 dnc:
   label: records.dancer
 dnr:

--- a/config/editor_profiles/default/configurations/SourceLabels.yml
+++ b/config/editor_profiles/default/configurations/SourceLabels.yml
@@ -787,7 +787,7 @@ cph:
 cst:
   label: records.costume_designer
 ctb:
-  label: records.co-composer
+  label: records.co_composer
 c|b:
   label: records.cf_minor
 c|x:

--- a/config/locales/marc_records/de.yml
+++ b/config/locales/marc_records/de.yml
@@ -316,7 +316,7 @@ de:
     chronological_term: Datierungen
     city: Ort
     clef: Schlüssel
-    co-composer: Mitkomponist
+    co_composer: Mitkomponist
     coded_date: Datum und Ort eines Ereignisses (codiert)
     coded_instrumentation: Kodierte Besetzung
     collaborator: Mitverfasser

--- a/config/locales/marc_records/en.yml
+++ b/config/locales/marc_records/en.yml
@@ -316,7 +316,7 @@ en:
     chronological_term: Chronological term
     city: City
     clef: Clef
-    co-composer: Co-composer
+    co_composer: Co-composer
     coded_date: Coded date
     coded_instrumentation: Coded instrumentation
     collaborator: Collaborator

--- a/config/locales/marc_records/es.yml
+++ b/config/locales/marc_records/es.yml
@@ -316,7 +316,7 @@ es:
     chronological_term: Término cronológico
     city: Ciudad
     clef: Clave
-    co-composer: Co-compositor
+    co_composer: Co-compositor
     coded_date: Fecha codificada
     coded_instrumentation: Intrumentación codificada
     collaborator: Colaborador

--- a/config/locales/marc_records/fr.yml
+++ b/config/locales/marc_records/fr.yml
@@ -317,7 +317,7 @@ fr:
     chronological_term: Datation
     city: Ville
     clef: Clé
-    co-composer: Compositeur secondaire
+    co_composer: Compositeur secondaire
     coded_date: Date et lieu d'un événement
     coded_instrumentation: Instrumentation codée
     collaborator: Collaborateur

--- a/config/locales/marc_records/it.yml
+++ b/config/locales/marc_records/it.yml
@@ -317,7 +317,7 @@ it:
     chronological_term: Date
     city: Città
     clef: Chiave
-    co-composer: Compositore secondario
+    co_composer: Compositore secondario
     coded_date: Data e luogo di un evento
     coded_instrumentation: Codice della strumentazione
     collaborator: Collaboratore

--- a/config/locales/marc_records/pl.yml
+++ b/config/locales/marc_records/pl.yml
@@ -316,7 +316,7 @@ pl:
     chronological_term: Datowanie
     city: Miejscowość
     clef: Klucz
-    co-composer: Współkompozytor
+    co_composer: Współkompozytor
     coded_date: Znormalizowana data
     coded_instrumentation: Standaryzowany zapis instrumentacji
     collaborator: Współtwórca

--- a/config/locales/marc_records/pt.yml
+++ b/config/locales/marc_records/pt.yml
@@ -316,7 +316,7 @@ pt:
     chronological_term: ''
     city: ''
     clef: Clave
-    co-composer: Co-compositor [ctb]
+    co_composer: Co-compositor [ctb]
     coded_date: Data codificada
     coded_instrumentation: Instrumentação codificada
     collaborator: ''


### PR DESCRIPTION
See rism-digital/translations#21 for details. This updates the local translation files for Muscat to bring them inline with the upstream changes, as well as updating the key for the places where it is used. 