### PR TITLE
Rename duplicate index name

### DIFF
--- a/db/migrate/20211025104732_rename_index_in_sources_to_people.rb
+++ b/db/migrate/20211025104732_rename_index_in_sources_to_people.rb
@@ -1,0 +1,6 @@
+class RenameIndexInSourcesToPeople < ActiveRecord::Migration[5.2]
+  def change
+    rename_index, :sources_to_sources, :unique_records, :unique_sources
+    rename_index, :sources_to_people,  :unique_records, :unique_sources_to_people
+  end
+end


### PR DESCRIPTION
Two tables have the same "unique_records" index name.  Although this seems not to be a problem with current MySQL/MariaDB versions, it may be a problem in the future, or using other database softwares, like SQLite (not supported, I know, but helped me to detect this duplication).

Fixes #1153