### PR TITLE
Remove an extra comma in rename_index migration

### DIFF
--- a/db/migrate/20211025104732_rename_index_in_sources_to_people.rb
+++ b/db/migrate/20211025104732_rename_index_in_sources_to_people.rb
@@ -1,6 +1,6 @@
 class RenameIndexInSourcesToPeople < ActiveRecord::Migration[5.2]
   def change
-    rename_index, :sources_to_sources, :unique_records, :unique_sources
-    rename_index, :sources_to_people,  :unique_records, :unique_sources_to_people
+    rename_index :sources_to_sources, :unique_records, :unique_sources
+    rename_index :sources_to_people,  :unique_records, :unique_sources_to_people
   end
 end


### PR DESCRIPTION
There is a syntax error: there is no comma after rename_index, sorry.