### PR TITLE
Normalise full_name_d removing diacritics and final punctuation

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -151,6 +151,7 @@ class Person < ApplicationRecord
     new_marc = MarcPerson.new(File.read(ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/config/marc/#{RISM::MARC}/person/default.marc")))
     new_marc.load_source true
     
+    self.full_name.sub!(/[ ,;\.]+$/, "")
     new_100 = MarcNode.new("person", "100", "", "1#")
     new_100.add_at(MarcNode.new("person", "a", self.full_name, nil), 0)
     

--- a/lib/marc_person.rb
+++ b/lib/marc_person.rb
@@ -10,8 +10,9 @@ class MarcPerson < Marc
 
     if node = first_occurance("100", "a")
       if node.content
-        full_name = node.content.truncate(128)
-        full_name_d = node.content.downcase.truncate(128)
+        full_name = node.content.truncate(128).sub(/[ ,;\.]+$/, "")
+        full_name_d = I18n.transliterate(full_name.downcase)
+        full_name_d = full_name.downcase if full_name_d.include? "???"
       end
     end
     


### PR DESCRIPTION
Documentation for Person model states that full_name_d should be normalised
to downcase and with diacritics removed, but currently it isn't so.  This
patch uses Rails I18n.transliterate, with the known limitation that it only
works for Latin alphabets.  As for other alphabets it returns a string full
of question marks, this patch reverses this damage using the current simpler
downcase normalisation.  Fixes #1165.