### PR TITLE
Remove final punctuation from personal life dates

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -155,6 +155,7 @@ class Person < ApplicationRecord
     new_100.add_at(MarcNode.new("person", "a", self.full_name, nil), 0)
     
     if self.life_dates
+      self.life_dates.sub!(/[ ,;\.]+$/, "")
       new_100.add_at(MarcNode.new("person", "d", self.life_dates, nil), 1)
     end
     

--- a/lib/marc_person.rb
+++ b/lib/marc_person.rb
@@ -17,7 +17,7 @@ class MarcPerson < Marc
     
     if node = first_occurance("100", "d")
       if node.content
-        dates = node.content.truncate(24)
+        dates = node.content.truncate(24).sub(/[ ,;\.]+$/, "")
       end
     end
     


### PR DESCRIPTION
Often, life dates coming from external Marc sources end with punctuation.
Remove it before create the personal authority record.  Fixes #1169