### PR TITLE
Add a to_h method to Marc tags to access its subfields

### DIFF
--- a/lib/marc_node.rb
+++ b/lib/marc_node.rb
@@ -489,7 +489,35 @@ class MarcNode
     end
     return out
   end
-  
+
+  # Convert subfields to hash, optionally as list or stripping punctuation
+  def to_h(as_list: false, strip_punctuation: false)
+    subfields = {}
+    content = looked_up_content if looked_up_content
+    if @tag =~ /^\d\d\d$/
+      if @tag >= "010"
+        @children.each do |child|
+          field = child.to_s
+          if field.start_with? "$"
+            subfield = field[1]
+            if strip_punctuation
+              value = field[2..].sub(/[ ,;\.]+$/, "")
+            else
+              value = field[2..]
+            end
+            if as_list
+              subfields[subfield] ||= []
+              subfields[subfield] << value
+            else
+              subfields[subfield] = value
+            end
+          end
+        end
+      end
+    end
+    subfields
+  end
+
   # Set the foreign object
   def foreign_object=(object)
     @foreign_object = object

--- a/lib/marc_node.rb
+++ b/lib/marc_node.rb
@@ -501,7 +501,7 @@ class MarcNode
           if field.start_with? "$"
             subfield = field[1]
             if strip_punctuation
-              value = field[2..].sub(/[ ,;\.]+$/, "")
+              value = field[2..].sub(/[ ,;:\.]+$/, "")
             else
               value = field[2..]
             end

--- a/lib/marc_node.rb
+++ b/lib/marc_node.rb
@@ -509,7 +509,7 @@ class MarcNode
               subfields[subfield] ||= []
               subfields[subfield] << value
             else
-              subfields[subfield] = value
+              subfields[subfield] ||= value
             end
           end
         end


### PR DESCRIPTION
Allow Marc subfields to be accessed like a hash, so it is easy to extract
all subfields of a tag or check the existence or not of a subfield.
Optionally, values can be returned as a list (as_list boolean parameter, for
repetable subfields), and final punctuation can also be optionally stripped
(strip_punctuation boolean parameter).