### PR TITLE
Implement $a and $b in institutions

### DIFF
--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -196,6 +196,7 @@ class Institution < ApplicationRecord
 
     # std_title
     self.name, self.place = marc.get_name_and_place
+    self.corporate_name, self.subordinate_unit = marc.get_corporate_name_and_subordinate_unit
     self.address, self.url = marc.get_address_and_url
     self.siglum = marc.get_siglum
     self.marc_source = self.marc.to_marc

--- a/config/marc/tag_config_institution.yml
+++ b/config/marc/tag_config_institution.yml
@@ -309,7 +309,11 @@
     - - a
       - :occurrences: "?"
         :foreign_class: ^0
-        :foreign_field: name
+        :foreign_field: corporate_name
+    - - b
+      - :occurrences: "?"
+        :foreign_class: ^0
+        :foreign_field: subordinate_unit
   "856": 
     :master: u
     :indicator: "1#"

--- a/config/marc/tag_config_person.yml
+++ b/config/marc/tag_config_person.yml
@@ -144,9 +144,13 @@
         :foreign_field: id
         :no_show: true
     - - a
-      - :occurrences: "1"
+      - :occurrences: "?"
         :foreign_class: ^0
-        :foreign_field: name
+        :foreign_field: corporate_name
+    - - b
+      - :occurrences: "?"
+        :foreign_class: ^0
+        :foreign_field: subordinate_unit
   "550":
     :master: a
     :indicator: "##"

--- a/config/marc/tag_config_source.yml
+++ b/config/marc/tag_config_source.yml
@@ -657,9 +657,11 @@
     - - a
       - :occurrences: "?"
         :foreign_class: ^0
-        :foreign_field: name
+        :foreign_field: corporate_name
     - - b
-      - :occurrences: "*"
+      - :occurrences: "?"
+        :foreign_class: ^0
+        :foreign_field: subordinate_unit
     - - c
       - :occurrences: "*"
     - - g

--- a/db/migrate/20221007081534_add_corporate_name_and_subordiate_unit_to_institutions.rb
+++ b/db/migrate/20221007081534_add_corporate_name_and_subordiate_unit_to_institutions.rb
@@ -1,0 +1,6 @@
+class AddCorporateNameAndSubordiateUnitToInstitutions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :institutions, :corporate_name, :string
+    add_column :institutions, :subordinate_unit, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -164,6 +164,8 @@ ActiveRecord::Schema.define(version: 2021_05_14_043225) do
     t.text "alternates"
     t.text "notes"
     t.integer "lock_version", default: 0, null: false
+    t.string "corporate_name"
+    t.string "subordinate_unit"
     t.index ["siglum"], name: "index_institutions_on_siglum"
     t.index ["wf_stage"], name: "index_institutions_on_wf_stage"
   end

--- a/lib/marc_institution.rb
+++ b/lib/marc_institution.rb
@@ -10,7 +10,11 @@ class MarcInstitution < Marc
 
     if node = first_occurance("110", "a")
       if node.content
-        name = node.content.truncate(128)
+        name = node.content
+        if node = first_occurance("110", "b")
+          name += " #{node.content}" if node.content
+        end
+        name = name.truncate(255)
       end
     end
     
@@ -21,6 +25,21 @@ class MarcInstitution < Marc
     end
     [name, place]
   end
+
+  def get_corporate_name_and_subordinate_unit
+    corporate_name = ""
+    subordinate_unit = ""
+
+    if node = first_occurance("110", "a")
+      corporate_name = node.content.truncate(255) if node.content
+    end
+
+    if node = first_occurance("110", "b")
+      subordinate_unit = node.content.truncate(255) if node.content
+    end
+    [corporate_name, subordinate_unit]
+  end
+
   def get_address_and_url
     address = ""
     url = ""


### PR DESCRIPTION
Institutional authority records and indices have the added complexity that the name is split in two subfields: $a for corporate name and $b for subordinate unit (see https://www.loc.gov/marc/authority/ad110.html).

This patch addresses both the authority records attributes and indices in Muscat with the following principles in mind:

* Keep the changes as minimal as possible.
* Do not change Muscat current behaviour if no $b is used in any institutional field.

The patch keeps the current name attribute, but now it is the concatenation of $a and $b (not just $a as before), and adds a new one just for $a (called corporate_name), and another for just $b (called subordinate_unit), that need a migration.

This patch adjustes yaml config files for marc institution, person and source.

Closes #1196 following the discussion at #1171