### PR TITLE
Add subtitle (245 $b) to title (245 $a) attribute

### DIFF
--- a/lib/marc_source.rb
+++ b/lib/marc_source.rb
@@ -180,6 +180,9 @@ class MarcSource < Marc
     if node = first_occurance(ms_title_field, "a")
       ms_title = node.content
     end
+    if node = first_occurance(ms_title_field, "b")
+      ms_title += " #{node.content}" if node.content
+    end
 
     ms_title_d = DictionaryOrder::normalize(ms_title)
    


### PR DESCRIPTION
The meaning and the identification of many works without subtitle is less clear without it.  This patch adds the subtitle to the title and it only affects how titles are displayed in the internal Muscat maintenance pages. It does not affect sites that do not use $b in 245 field.

Closes #1288