### PR TITLE
Recognize subunit as different from monograph in sources leader

### DIFF
--- a/lib/marc_source.rb
+++ b/lib/marc_source.rb
@@ -244,8 +244,10 @@ class MarcSource < Marc
       rt = RECORD_TYPES[:collection]
     elsif leader.match(/......d[dm].............../)
       rt = RECORD_TYPES[:source]
-    elsif leader.match(/......c[dm].............../)
+    elsif leader.match(/......cd.............../)
       rt = RECORD_TYPES[:edition_content]
+    elsif leader.match(/......cm.............../)
+      rt = RECORD_TYPES[:edition]
     elsif leader.match(/......tm.............../)
       rt = RECORD_TYPES[:libretto_source]
     elsif leader.match(/......am.............../)


### PR DESCRIPTION
Marc21 bibliographic level distinguishes between d (subunit) and m (monograph/item) that, in Muscat record types, correspond to edition_content (Printed music edition, item in collection) and edition (Printed music edition, collection parent record or individual item).

https://www.loc.gov/marc/bibliographic/bdleader.html

Split the logic between both types instead of putting all together as edition_content.

Closes #1318