### PR TITLE
Implement $a and $b in institutions, v2

### DIFF
--- a/app/admin/institution.rb
+++ b/app/admin/institution.rb
@@ -22,10 +22,10 @@ ActiveAdmin.register Institution do
   #
   # temporarily allow all parameters
   controller do
-
-    autocomplete :institution, [:siglum, :name], :display_value => :autocomplete_label_siglum, :extra_data => [:siglum, :name], :required => :siglum
-    autocomplete :institution, :name, :display_value => :autocomplete_label_name, :extra_data => [:siglum, :name]
-
+    
+    autocomplete :institution, [:siglum, :full_name], :display_value => :autocomplete_label_siglum, :extra_data => [:siglum, :full_name], :required => :siglum
+    autocomplete :institution, :full_name, :display_value => :autocomplete_label_name, :extra_data => [:siglum, :full_name]
+    
     after_destroy :check_model_errors
     before_create do |item|
       item.user = current_user
@@ -113,7 +113,7 @@ ActiveAdmin.register Institution do
   ###########
 
   # Solr search all fields: "_equal"
-  filter :name_equals, :label => proc {I18n.t(:any_field_contains)}, :as => :string
+  filter :full_name_equals, :label => proc {I18n.t(:any_field_contains)}, :as => :string
   filter :"110g_facet_contains", :label => proc{I18n.t(:library_sigla_contains)}, :as => :string
   filter :place_contains, :label => proc {I18n.t(:filter_place)}, :as => :string
   filter :"667a_contains", :label => proc{I18n.t(:internal_note_contains)}, :as => :string
@@ -144,7 +144,7 @@ ActiveAdmin.register Institution do
     column (I18n.t :filter_id), :id
 
     column (I18n.t :filter_siglum), :siglum
-    column (I18n.t :filter_location_and_name), :name
+    column (I18n.t :filter_location_and_name), :full_name
     column (I18n.t :filter_place), :place
     column (I18n.t :filter_sources), :src_count_order, sortable: :src_count_order do |element|
       all_hits = @arbre_context.assigns[:hits]
@@ -164,8 +164,8 @@ ActiveAdmin.register Institution do
   ##########
   ## Show ##
   ##########
-
-  show :title => proc{ active_admin_auth_show_title( @item.name, @item.siglum, @item.id) } do
+  
+  show :title => proc{ active_admin_auth_show_title( @item.full_name, @item.siglum, @item.id) } do
     # @item retrived by from the controller is not available there. We need to get it from the @arbre_context
     active_admin_navigation_bar( self )
 
@@ -183,7 +183,7 @@ ActiveAdmin.register Institution do
           table_for(collection, sortable: true) do
             column :id do |p| link_to p.id, controller: :institutions, action: :show, id: p.id end
             column :siglum
-            column :name
+            column :full_name
             column :place
           end
         end

--- a/app/admin/person.rb
+++ b/app/admin/person.rb
@@ -258,7 +258,7 @@ ActiveAdmin.register Person do
       context.table_for(context.collection) do |cr|
         context.column "id", :id
         context.column (I18n.t :filter_siglum), :siglum
-        context.column (I18n.t :filter_name), :name
+        context.column (I18n.t :filter_name), :full_name
         context.column (I18n.t :filter_place), :place
         if !is_selection_mode?
           context.column "" do |ins|

--- a/app/helpers/active_admin/views_helper.rb
+++ b/app/helpers/active_admin/views_helper.rb
@@ -74,6 +74,7 @@ module ActiveAdmin::ViewsHelper
     
     name = "[Model does not have a label]"
     name = item.name if item.respond_to?(:name)
+    name = item.full_name if item.respond_to?(:full_name)
     name = item.title if item.respond_to?(:title)
     name = item.autocomplete_label if item.respond_to?(:autocomplete_label)
     

--- a/app/models/digital_object_link.rb
+++ b/app/models/digital_object_link.rb
@@ -8,7 +8,8 @@ class DigitalObjectLink < ApplicationRecord
 	
     def description
         return object_link.std_title if (object_link_type == "Source")
-        return object_link.name if (object_link_type == "Person" || object_link_type == "Institution")
+        return object_link.name if (object_link_type == "Person")
+        return object_link.full_name if (object_link_type == "Institution")
         "[Unspecified]"
     end
 

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -2,7 +2,7 @@
 #
 # === Fields
 # * <tt>siglum</tt> - RISM sigla of the lib
-# * <tt>name</tt> -  Fullname of the lib
+# * <tt>full_name</tt> -  Fullname of the lib
 # * <tt>address</tt>
 # * <tt>url</tt>
 # * <tt>phone</tt> 
@@ -84,6 +84,7 @@ class Institution < ApplicationRecord
   attr_accessor :suppress_update_workgroups_trigger
 
   alias_attribute :id_for_fulltext, :id
+  alias_attribute :name, :full_name
 
   enum wf_stage: [ :inprogress, :published, :deleted, :deprecated ]
   enum wf_audit: [ :full, :abbreviated, :retro, :imported ]
@@ -145,18 +146,19 @@ class Institution < ApplicationRecord
     new_marc = MarcInstitution.new(File.read(ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/config/marc/#{RISM::MARC}/institution/default.marc")))
     new_marc.load_source true
     
-    new_100 = MarcNode.new("institution", "110", "", "1#")
-    new_100.add_at(MarcNode.new("institution", "c", self.place, nil), 0) if self.place != nil
-    new_100.add_at(MarcNode.new("institution", "g", self.siglum, nil), 0) if self.siglum != nil
-    new_100.add_at(MarcNode.new("institution", "a", self.name, nil), 0)
+    new_110 = MarcNode.new("institution", "110", "", "1#")
+    new_110.add_at(MarcNode.new("institution", "c", self.place, nil), 0) if self.place != nil
+    new_110.add_at(MarcNode.new("institution", "g", self.siglum, nil), 0) if self.siglum != nil
+    new_110.add_at(MarcNode.new("institution", "a", self.corporate_name, nil), 0)
+    new_110.add_at(MarcNode.new("institution", "b", self.subordinate_unit, nil), 0) if self.subordinate_unit != nil
     
-    new_marc.root.children.insert(new_marc.get_insert_position("110"), new_100)
+    new_marc.root.children.insert(new_marc.get_insert_position("110"), new_110)
     
     if self.alternates != nil and !self.alternates.empty?
-      new_400 = MarcNode.new("institution", "410", "", "1#")
-      new_400.add_at(MarcNode.new("institution", "a", self.alternates, nil), 0)
+      new_410 = MarcNode.new("institution", "410", "", "1#")
+      new_410.add_at(MarcNode.new("institution", "a", self.alternates, nil), 0)
     
-      new_marc.root.children.insert(new_marc.get_insert_position("410"), new_400)
+      new_marc.root.children.insert(new_marc.get_insert_position("410"), new_410)
     end
     
     if self.url || self.address
@@ -199,7 +201,8 @@ class Institution < ApplicationRecord
     self.id = marc_source_id if marc_source_id and marc_source_id != "__TEMP__"
 
     # std_title
-    self.name, self.place = marc.get_name_and_place
+    self.full_name, self.place = marc.get_full_name_and_place
+    self.corporate_name, self.subordinate_unit = marc.get_corporate_name_and_subordinate_unit
     self.address, self.url = marc.get_address_and_url
     self.siglum = marc.get_siglum
     self.marc_source = self.marc.to_marc
@@ -265,16 +268,16 @@ class Institution < ApplicationRecord
   
   def autocomplete_label
     sigla = siglum != nil && !siglum.empty? ? "#{siglum} " : ""
-    "#{sigla}#{name}"
+    "#{sigla}#{full_name}"
   end
   
   def autocomplete_label_siglum
-    "#{siglum} (#{name})"
+    "#{siglum} (#{full_name})"
   end
   
   def autocomplete_label_name
     sigla = siglum != nil && !siglum.empty? ? " [#{siglum}]" : ""
-    "#{name}#{sigla}"
+    "#{full_name}#{sigla}"
   end
  
   ransacker :"110g_facet", proc{ |v| } do |parent| parent.table[:id] end

--- a/app/views/marc_show/_show_institution.html.erb
+++ b/app/views/marc_show/_show_institution.html.erb
@@ -1,8 +1,10 @@
 <%
     a_tag = tag.fetch_first_by_tag(:a)
-	g_tag = tag.fetch_first_by_tag(:g)
+    b_tag = tag.fetch_first_by_tag(:b)
+    g_tag = tag.fetch_first_by_tag(:g)
     four_tags = tag.fetch_all_by_tag(:"4")
 	institution = (a_tag ? a_tag.looked_up_content : "")
+	institution += " #{b_tag.looked_up_content}" if b_tag
 	master_tag = @item.marc.config.get_master(tag.tag) rescue master_tag = ""
 	db_id = tag.fetch_first_by_tag(master_tag).content rescue db_id = ""
 -%>

--- a/config/editor_profiles/default/configurations/InstitutionFormOptions.yml
+++ b/config/editor_profiles/default/configurations/InstitutionFormOptions.yml
@@ -345,6 +345,7 @@
       - type: institution
         editor_partial: subfield_secondary
       - cols: 4
+    - - "b"
     columns: 4
 
 

--- a/config/editor_profiles/default/configurations/InstitutionLabels.yml
+++ b/config/editor_profiles/default/configurations/InstitutionLabels.yml
@@ -188,6 +188,8 @@
   fields:
     a:
       label: records.related_institution
+    b:
+      label: records.subordinate_unit
   label: records.related_institution
 '856':
   fields:

--- a/config/editor_profiles/default/configurations/PersonFormOptions.yml
+++ b/config/editor_profiles/default/configurations/PersonFormOptions.yml
@@ -266,6 +266,7 @@
       - type: institution
         editor_partial: subfield_secondary
       - cols: 4
+    - - "b"
     columns: 4
 "549": 
   layout: 

--- a/config/editor_profiles/default/configurations/PersonLabels.yml
+++ b/config/editor_profiles/default/configurations/PersonLabels.yml
@@ -79,6 +79,8 @@
   fields:
     a:
       label: records.associated_institution
+    b:
+      label: records.subordinate_unit
   label: records.associated_institution
 '550':
   fields:

--- a/config/marc/tag_config_institution.yml
+++ b/config/marc/tag_config_institution.yml
@@ -107,7 +107,7 @@
     - - a
       - :occurrences: "1"
     - - b
-      - :occurrences: "*"
+      - :occurrences: "?"
     - - c
       - :occurrences: "?"
     - - g
@@ -308,7 +308,11 @@
     - - a
       - :occurrences: "?"
         :foreign_class: ^0
-        :foreign_field: name
+        :foreign_field: corporate_name
+    - - b
+      - :occurrences: "?"
+        :foreign_class: ^0
+        :foreign_field: subordinate_unit
   "856": 
     :master: u
     :indicator: "1#"

--- a/config/marc/tag_config_person.yml
+++ b/config/marc/tag_config_person.yml
@@ -146,7 +146,10 @@
     - - a
       - :occurrences: "1"
         :foreign_class: ^0
-        :foreign_field: name
+        :foreign_field: corporate_name
+    - - b
+      - :occurrences: "?"
+        :foreign_field: subordinate_unit
   "550":
     :master: a
     :indicator: "##"
@@ -257,9 +260,12 @@
         :foreign_field: id
         :no_show: true
     - - a
-      - :occurrences: "?"
+      - :occurrences: "1"
         :foreign_class: ^0
-        :foreign_field: siglum
+        :foreign_field: corporate_name
+    - - b
+      - :occurrences: "?"
+        :foreign_field: subordinate_unit
   "856":
     :master: u
     :indicator: "##"

--- a/db/migrate/20230124122110_add_corporate_name_and_subordinate_unit_to_institutions.rb
+++ b/db/migrate/20230124122110_add_corporate_name_and_subordinate_unit_to_institutions.rb
@@ -1,0 +1,7 @@
+class AddCorporateNameAndSubordinateUnitToInstitutions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :institutions, :corporate_name, :string
+    add_column :institutions, :subordinate_unit, :string
+    rename_column :institutions, :name, :full_name
+  end
+end

--- a/lib/notification_matcher.rb
+++ b/lib/notification_matcher.rb
@@ -5,7 +5,7 @@ class NotificationMatcher
   ALLOWED_PROPERTIES = {
     source: [:record_type, :std_title, :composer, :title, :shelf_mark, :lib_siglum, :follow],
     work: [:title, :form, :notes, :composer, :follow],
-    institution: [:siglum, :name, :address, :place, :comments, :alternates, :notes, :follow]
+    institution: [:siglum, :full_name, :address, :place, :comments, :alternates, :notes, :follow]
   }
 
   SPECIAL_RULES = {


### PR DESCRIPTION
Institutional authority records and indices have the added complexity that the name is split in two subfields: $a for corporate name and $b for subordinate unit (see https://www.loc.gov/marc/authority/ad110.html).

Following @xhero request in #1287, this second version renames the old `name` attribute to `full_name`, while keeping `corporate_name` for $a and `subordinate_unit` for $b.  This attribute rename forces changes in other files, so it is larger and more invasive than the first one

This version has two limitations or drawbacks:

While testing it, I kept finding and "undefined method `name' for many hours of unsuccessful debugging, the only cure was an "alias_attribute :name, :full_name", which, I know, only hides the problem.

The second one is that autocomplete for institutions fields does no longer work, and I haven't been able to find why.