### PR TITLE
Escape data-scroll-target editor validation javascript element

### DIFF
--- a/app/assets/javascripts/marc_editor_validation.js
+++ b/app/assets/javascripts/marc_editor_validation.js
@@ -83,7 +83,7 @@ function _marc_validate_highlight( element, errorClass, validClass ) {
 	// Highlight the group in the sidebar
 	var panel = $(element).parents(".tab_panel");
 	var item_name = panel.attr("name");
-	var menu_item = $("a[data-scroll-target=" + item_name+ "]");
+	var menu_item = $('a[data-scroll-target="' + item_name+ '"]');
 	menu_item.addClass(errorClass);
 	
 	// Keep a reference of the error'd items
@@ -132,7 +132,7 @@ function _marc_validate_unhighlight( element, errorClass, validClass ) {
 	// class from the sidebar group
 	var panel = $(element).parents(".tab_panel");
 	var item_name = panel.attr("name");
-	var menu_item = $("a[data-scroll-target='" + item_name+ "']");
+	var menu_item = $('a[data-scroll-target="' + item_name+ '"]');
 	var errors = menu_item.data("error-counter");
 	if (errors != undefined) {
 		


### PR DESCRIPTION
As the names of data-scroll-target editor validation target is taken from the translated texts, when there is an apostrophe (') the javascript parser cannot know where the name ends.  Use a double quote to enclose the element.

Closes #1360