### PR TITLE
Fix link to BNF catalogue

### DIFF
--- a/app/views/marc_show/_show_dnb_link.html.erb
+++ b/app/views/marc_show/_show_dnb_link.html.erb
@@ -8,7 +8,7 @@
     two_tag = t.fetch_first_by_tag("2")
     if a_tag && two_tag && a_tag.content && two_tag.content
       if two_tag.content == "BNF"
-        content << link_to("BNF: " + a_tag.content, "https://data.bnf.fr/ark:/12148/"+a_tag.content, :target => "_blank") if (a_tag && a_tag.content)
+        content << link_to("BNF: " + a_tag.content, "https://data.bnf.fr/ark:/12148/cb"+a_tag.content, :target => "_blank") if (a_tag && a_tag.content)
       elsif two_tag.content == "DNB"
         content << link_to("DNB: " + a_tag.content, "http://d-nb.info/gnd/"+a_tag.content, :target => "_blank") if (a_tag && a_tag.content)
       elsif two_tag.content == "MBZ"


### PR DESCRIPTION
The URL prefix for BnF identifiers was missing the initial "cb". 