### PR TITLE
Fix current folder filter behaviour and create a couple more

### DIFF
--- a/app/admin/folder.rb
+++ b/app/admin/folder.rb
@@ -176,12 +176,12 @@ ActiveAdmin.register Folder do
   filter :wf_owner_equals, :label => proc { I18n.t(:filter_owner) },
          as: :select,
          collection: proc {
-           if current_user.has_any_role?(:editor, :admin)
-             User.sort_all_by_last_name.map{|u| [u.name, u.id]}
-           else
-             [[current_user.name, "wf_owner:#{current_user.id}"]]
-           end
-         }
+    if current_user.has_any_role?(:editor, :admin)
+      User.find(Folder.distinct.pluck(:wf_owner)).pluck(:name, :id).sort
+    else
+      [[current_user.name, "wf_owner:#{current_user.id}"]]
+    end
+  }
   # Filter by folder type
   filter :folder_type, :label => proc { I18n.t(:filter_folder_type) },
          as: :select,

--- a/app/admin/folder.rb
+++ b/app/admin/folder.rb
@@ -168,10 +168,24 @@ ActiveAdmin.register Folder do
   ###########
   ## Index ##
   ###########
-  
-  # Solr search all fields: "_equal"
-  filter :name_equals, :label => proc {I18n.t(:any_field_contains)}, :as => :string
-  
+
+  # Solr search substring: "_cont"
+  filter :name_cont, :label => proc { I18n.t(:any_field_contains) },
+         as: :string
+  # Filter by the wf_owner
+  filter :wf_owner_equals, :label => proc { I18n.t(:filter_owner) },
+         as: :select,
+         collection: proc {
+           if current_user.has_any_role?(:editor, :admin)
+             User.sort_all_by_last_name.map{|u| [u.name, u.id]}
+           else
+             [[current_user.name, "wf_owner:#{current_user.id}"]]
+           end
+         }
+  # Filter by folder type
+  filter :folder_type, :label => proc { I18n.t(:filter_folder_type) },
+         as: :select,
+         collection: proc { Folder.distinct.pluck(:folder_type) }
 
   index :download_links => false do |ad|
     selectable_column


### PR DESCRIPTION
Make sure that the current filter for "contains" does a substring search, not a full name search, and create a filter by owner and another for folder type.

Closes #1389

Thanks to @ivan-mr from @CodiTramuntana for his help with procs and collections.