### PR TITLE
Do not allow the creation of folders of users

### DIFF
--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -77,9 +77,6 @@ ActiveAdmin.register User do
     render :partial => "activeadmin/section_sidebar_index"
   end
  
-  # Include the folder actions
-  include FolderControllerActions
-  
   ##########
   ## Show ##
   ##########


### PR DESCRIPTION
Closes #1391.  Massive deletion of users is still allowed, as it is not clear that this ability should be removed.

Thanks to @ivan-mr from @CodiTramuntana for finding the trivial but not obvious way of fixing it.