### PR TITLE
Rename obsolete catalogues filter text to publications

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -414,7 +414,7 @@ class CatalogController < ApplicationController
     end
     
     config.add_search_field("publication") do |field|
-      field.label = :filter_catalog
+      field.label = :filter_publications
       field.include_in_simple_select = false
       field.solr_parameters = { :qf => "690a_text" }
     end

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -451,7 +451,7 @@ ca:
   filter_author_or_editor: "Autor/editor"
   filter_autograph_of: "Autògraf de"
   filter_birth_place: "Lloc de naixement"
-  filter_catalog: "Catàleg"
+  filter_publications: "Publicacions"
   filter_category_type: "Categoria"
   filter_collection: "Col·lecció"
   filter_comment: "Comentari"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -451,7 +451,7 @@ de:
   filter_author_or_editor: "Autor/Herausgeber"
   filter_autograph_of: "Autograph von"
   filter_birth_place: "Geburtsort"
-  filter_catalog: "WV / Katalog"
+  filter_publications: "Publikationen"
   filter_collection: "Sammlung"
   filter_category_type: "Kategorie"
   filter_comment: "Kommentar"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -452,7 +452,7 @@ en:
   filter_author_or_editor: "Author/Editor"
   filter_autograph_of: "Autograph of"
   filter_birth_place: "Birth place"
-  filter_catalog: "Catalogue"
+  filter_publications: "Publications"
   filter_category_type: "Category"
   filter_collection: "Collection"
   filter_comment: "Comment"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -451,7 +451,7 @@ es:
   filter_author_or_editor: "Autor/Editor"
   filter_autograph_of: "Autógrafo de"
   filter_birth_place: "Lugar de nacimiento"
-  filter_catalog: "Catálogo"
+  filter_publications: "Publicaciones"
   filter_category_type: "Categoría"
   filter_collection: "Colección"
   filter_comment: "Comentario"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -452,7 +452,7 @@ fr:
   filter_author_or_editor: "Auteur/Éditeur"
   filter_autograph_of: "Autographe de"
   filter_birth_place: "Lieu de naissance"
-  filter_catalog: "Catalogue"
+  filter_publications: "Publications"
   filter_collection: "Collection"
   filter_category_type: "Catégorie"
   filter_comment: "Commentaire"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -457,7 +457,7 @@ it:
   filter_author_or_editor: "Autore/Editore"
   filter_autograph_of: "Autografo di"
   filter_birth_place: "Luogo di nascita"
-  filter_catalog: "Catalogo"
+  filter_publications: "Pubblicazioni"
   filter_category_type: "Categoria"
   filter_collection: "Collezione"
   filter_comment: "Commento"

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -452,7 +452,7 @@ pl:
   filter_author_or_editor: Autor / Edytor
   filter_autograph_of: Autograf autorstwa
   filter_birth_place: Miejsce urodzenia
-  filter_catalog: Katalog
+  filter_publications: Publikacje
   filter_category_type: Kategoria
   filter_collection: Kolekcja
   filter_comment: Komentarz

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -447,7 +447,7 @@ pt:
   filter_author_or_editor: "Autor/Editor"
   filter_autograph_of: "Autógrafo de"
   filter_birth_place: "Local de nascimento"
-  filter_catalog: "Catálogo"
+  filter_publications: "Publicaçaões"
   filter_category_type: "Categoria"
   filter_collection: "Coletânea"
   filter_comment: "Comentário"


### PR DESCRIPTION
There are still obsolete references to "catalogues" before being renamed to "publications", this time in the filter strings.

Part of #1028