### PR TITLE
Update HoldingBasicLabels.yml

### DIFF
--- a/config/editor_profiles/default/configurations/HoldingBasicLabels.yml
+++ b/config/editor_profiles/default/configurations/HoldingBasicLabels.yml
@@ -130,6 +130,8 @@
       label: records.institution
     b:
       label: records.department
+    c:
+      label: records.place
     g:
       label: records.attribution_qualifier
   label: records.additional_institution


### PR DESCRIPTION
The label for the 710$c place is missing in Holdings, see https://muscat.rism.info/admin/sources/990003040#holding_12237 This was copied from Sources.