### PR TITLE
Allow items to be added and removed from folders, v2

### DIFF
--- a/app/admin/digital_object.rb
+++ b/app/admin/digital_object.rb
@@ -238,6 +238,7 @@ ActiveAdmin.register DigitalObject do
     if digital_object.images?
       render :partial => "activeadmin/section_sidebar_do_links", :locals => { :item => digital_object }
     end
+    render :partial => "activeadmin/section_sidebar_folder_actions", :locals => { :item => digital_object }
   end
 
   ##########

--- a/app/admin/institution.rb
+++ b/app/admin/institution.rb
@@ -262,6 +262,10 @@ ActiveAdmin.register Institution do
     render :partial => "activeadmin/section_sidebar_show", :locals => { :item => institution }
   end
 
+  sidebar :folders, :only => :show do
+    render :partial => "activeadmin/section_sidebar_folder_actions", :locals => { :item => institution }
+  end
+
   ##########
   ## Edit ##
   ##########

--- a/app/admin/liturgical_feast.rb
+++ b/app/admin/liturgical_feast.rb
@@ -162,6 +162,10 @@ ActiveAdmin.register LiturgicalFeast do
     render :partial => "activeadmin/section_sidebar_show", :locals => { :item => liturgical_feast }
   end
   
+  sidebar :folders, :only => :show do
+    render :partial => "activeadmin/section_sidebar_folder_actions", :locals => { :item => liturgical_feast }
+  end
+
   ##########
   ## Edit ##
   ##########

--- a/app/admin/person.rb
+++ b/app/admin/person.rb
@@ -322,6 +322,10 @@ ActiveAdmin.register Person do
     render :partial => "people/library_pie"
   end
 
+  sidebar :folders, :only => :show do
+    render :partial => "activeadmin/section_sidebar_folder_actions", :locals => { :item => person }
+  end
+
   ##########
   ## Edit ##
   ##########

--- a/app/admin/place.rb
+++ b/app/admin/place.rb
@@ -243,6 +243,10 @@ ActiveAdmin.register Place do
     render :partial => "activeadmin/section_sidebar_show", :locals => { :item => place }
   end
 
+  sidebar :folders, :only => :show do
+    render :partial => "activeadmin/section_sidebar_folder_actions", :locals => { :item => place }
+  end
+
   ##########
   ## Edit ##
   ##########

--- a/app/admin/publication.rb
+++ b/app/admin/publication.rb
@@ -276,6 +276,10 @@ ActiveAdmin.register Publication do
     render :partial => "activeadmin/section_sidebar_show", :locals => { :item => publication }
   end
 
+  sidebar :folders, :only => :show do
+    render :partial => "activeadmin/section_sidebar_folder_actions", :locals => { :item => publication }
+  end
+
   ##########
   ## Edit ##
   ##########

--- a/app/admin/source.rb
+++ b/app/admin/source.rb
@@ -381,19 +381,21 @@ ActiveAdmin.register Source do
   # 8.0.1 #1190, make the sidebar floating only if there are no holdings
   sidebar :actions, :class => "sidebar_tabs" , :only => :show, if: proc{ resource.holdings.empty? } do
     render :partial => "activeadmin/section_sidebar_show", :locals => { :item => @arbre_context.assigns[:item] }
+    render :partial => "activeadmin/section_sidebar_folder_actions", :locals => { :item => item }
   end
 
   # Same sidebar as above, but when holdings are present. This is quite a kludge since :class cannot
-  # be created conditiolally using a proc{ !resource.holdings.empty? }, so the whole sidebar block
+  # be created conditionally using a proc{ !resource.holdings.empty? }, so the whole sidebar block
   # has to be repeated with a different if: ... do
   sidebar :actions, :only => :show, if: proc{ !resource.holdings.empty? } do
     render :partial => "activeadmin/section_sidebar_show", :locals => { :item => @arbre_context.assigns[:item] }
+    render :partial => "activeadmin/section_sidebar_folder_actions", :locals => { :item => item }
   end
 
   sidebar I18n.t(:holding_records), :only => :show , if: proc{ !resource.holdings.empty? } do
     render :partial => "holdings/holdings_sidebar_show"#, :locals => { :item => @arbre_context.assigns[:item] }
   end
-  
+
   ##########
   ## Edit ##
   ##########

--- a/app/admin/standard_term.rb
+++ b/app/admin/standard_term.rb
@@ -194,6 +194,10 @@ ActiveAdmin.register StandardTerm do
     render :partial => "activeadmin/section_sidebar_show", :locals => { :item => standard_term }
   end
   
+  sidebar :folders, :only => :show do
+    render :partial => "activeadmin/section_sidebar_folder_actions", :locals => { :item => standard_term }
+  end
+
   ##########
   ## Edit ##
   ##########

--- a/app/admin/standard_title.rb
+++ b/app/admin/standard_title.rb
@@ -178,6 +178,10 @@ ActiveAdmin.register StandardTitle do
     render :partial => "activeadmin/section_sidebar_show", :locals => { :item => standard_title }
   end
   
+  sidebar :folders, :only => :show do
+    render :partial => "activeadmin/section_sidebar_folder_actions", :locals => { :item => standard_title }
+  end
+
   ##########
   ## Edit ##
   ##########

--- a/app/admin/work.rb
+++ b/app/admin/work.rb
@@ -235,7 +235,10 @@ ActiveAdmin.register Work do
     render :partial => "activeadmin/section_sidebar_show", :locals => { :item => work }
   end
   
-  
+  sidebar :folders, :only => :show do
+    render :partial => "activeadmin/section_sidebar_folder_actions", :locals => { :item => work }
+  end
+
   ##########
   ## Edit ##
   ##########

--- a/app/admin/work_node.rb
+++ b/app/admin/work_node.rb
@@ -173,7 +173,10 @@ ActiveAdmin.register WorkNode do
     render :partial => "activeadmin/section_sidebar_show", :locals => { :item => work_node }
   end
   
-  
+  sidebar :folders, :only => :show do
+    render :partial => "activeadmin/section_sidebar_folder_actions", :locals => { :item => work_node }
+  end
+
   ##########
   ## Edit ##
   ##########

--- a/app/helpers/section_sidebar_folder_actions_helper.rb
+++ b/app/helpers/section_sidebar_folder_actions_helper.rb
@@ -1,0 +1,8 @@
+module SectionSidebarFolderActionsHelper
+  def define_attributes_for_section_sidebar_folder_actions(item)
+    @model_underscore_downcase = item.class.to_s.underscore.downcase
+    compatible_folders = Folder.where(folder_type: item.class)
+    @folders_with_this_item = compatible_folders.where(id: item.folder_items.pluck(:folder_id))
+    @folders_without_this_item = compatible_folders - @folders_with_this_item
+  end
+end

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -43,7 +43,7 @@ class Institution < ApplicationRecord
   has_and_belongs_to_many :standard_terms, join_table: "institutions_to_standard_terms"
   
   has_and_belongs_to_many :referring_holdings, class_name: "Holding", join_table: "holdings_to_institutions"
-  #has_many :folder_items, as: :item, dependent: :destroy
+  has_many :folder_items, as: :item, dependent: :destroy
   has_many :delayed_jobs, -> { where parent_type: "Institution" }, class_name: 'Delayed::Backend::ActiveRecord::Job', foreign_key: "parent_id"
   has_and_belongs_to_many :workgroups
   belongs_to :user, :foreign_key => "wf_owner"
@@ -86,6 +86,7 @@ class Institution < ApplicationRecord
   attr_accessor :suppress_update_workgroups_trigger
 
   alias_attribute :id_for_fulltext, :id
+  alias_attribute :name, :full_name # activeadmin needs the name attribute
 
   enum wf_stage: [ :inprogress, :published, :deleted, :deprecated ]
   enum wf_audit: [ :full, :abbreviated, :retro, :imported ]

--- a/app/views/activeadmin/_section_sidebar_folder_actions.html.erb
+++ b/app/views/activeadmin/_section_sidebar_folder_actions.html.erb
@@ -1,0 +1,31 @@
+<% model_underscore_downcase = item.class.to_s.underscore.downcase %>
+<% compatible_folders = Folder.where(folder_type: item.class) %>
+<% folders_with_this_item = compatible_folders.where(id: item.folder_items.pluck(:folder_id)) %>
+<% folders_without_this_item = compatible_folders - folders_with_this_item %>
+
+<% if folders_with_this_item.any? %>
+    <ul class="dropdown_menu_list">
+	<li class="muscat_icon_separator">
+            <% select_options = folders_with_this_item.sort_by{ |f| f.name.downcase }.map{ |f| [f.name, f.id] } %>
+            <%= form_tag send("remove_item_from_folder_admin_#{model_underscore_downcase}_path", item.id), method: 'delete' do %>
+		<%= select_tag :folder_id, options_for_select(select_options), {include_blank: I18n.t(:choose_folder), required: true} %>
+		<%= hidden_field_tag "batch_action", "remove_single_from_folder" %>
+		<%= submit_tag I18n.t :remove_item_from_folder %>
+            <% end %>
+	</li>
+    </ul>
+<% end %>
+
+<% if folders_without_this_item.any? %>
+    <ul class="dropdown_menu_list">
+        <li class="muscat_icon_separator">
+            <% select_options = folders_without_this_item.sort_by{ |f| f.name.downcase }.map{ |f| [f.name, f.id] } %>
+            <%= form_tag send("add_item_to_folder_admin_#{model_underscore_downcase}_path"), method: 'post' do %>
+                <%= select_tag :folder_id, options_for_select(select_options), {include_blank: I18n.t(:choose_folder), required: true} %>
+                <%= hidden_field_tag :model, item.class.to_s %>
+                <%= hidden_field_tag :item_id, item.id %>
+                <%= submit_tag I18n.t :add_item_to_folder %>
+            <% end %>
+        </li>
+    </ul>
+<% end %>

--- a/app/views/activeadmin/_section_sidebar_folder_actions.html.erb
+++ b/app/views/activeadmin/_section_sidebar_folder_actions.html.erb
@@ -1,13 +1,10 @@
-<% model_underscore_downcase = item.class.to_s.underscore.downcase %>
-<% compatible_folders = Folder.where(folder_type: item.class) %>
-<% folders_with_this_item = compatible_folders.where(id: item.folder_items.pluck(:folder_id)) %>
-<% folders_without_this_item = compatible_folders - folders_with_this_item %>
+<% define_attributes_for_section_sidebar_folder_actions(item) %>
 
-<% if folders_with_this_item.any? %>
+<% if @folders_with_this_item.any? %>
     <ul class="dropdown_menu_list">
 	<li class="muscat_icon_separator">
-            <% select_options = folders_with_this_item.sort_by{ |f| f.name.downcase }.map{ |f| [f.name, f.id] } %>
-            <%= form_tag send("remove_item_from_folder_admin_#{model_underscore_downcase}_path", item.id), method: 'delete' do %>
+            <% select_options = @folders_with_this_item.sort_by{ |f| f.name.downcase }.map{ |f| [f.name, f.id] } %>
+            <%= form_tag send("remove_item_from_folder_admin_#{@model_underscore_downcase}_path", item.id), method: 'delete' do %>
 		<%= select_tag :folder_id, options_for_select(select_options), {include_blank: I18n.t(:choose_folder), required: true} %>
 		<%= hidden_field_tag "batch_action", "remove_single_from_folder" %>
 		<%= submit_tag I18n.t :remove_item_from_folder %>
@@ -16,11 +13,11 @@
     </ul>
 <% end %>
 
-<% if folders_without_this_item.any? %>
+<% if @folders_without_this_item.any? %>
     <ul class="dropdown_menu_list">
         <li class="muscat_icon_separator">
-            <% select_options = folders_without_this_item.sort_by{ |f| f.name.downcase }.map{ |f| [f.name, f.id] } %>
-            <%= form_tag send("add_item_to_folder_admin_#{model_underscore_downcase}_path"), method: 'post' do %>
+            <% select_options = @folders_without_this_item.sort_by{ |f| f.name.downcase }.map{ |f| [f.name, f.id] } %>
+            <%= form_tag send("add_item_to_folder_admin_#{@model_underscore_downcase}_path"), method: 'post' do %>
                 <%= select_tag :folder_id, options_for_select(select_options), {include_blank: I18n.t(:choose_folder), required: true} %>
                 <%= hidden_field_tag :model, item.class.to_s %>
                 <%= hidden_field_tag :item_id, item.id %>
@@ -29,3 +26,4 @@
         </li>
     </ul>
 <% end %>
+

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -380,7 +380,9 @@ ca:
   export_folder_csv: "Exporta la carpeta en format CSV"
   export_folder_raw: "Exporta la carpeta en format Muscat MARC"
   validate_folder: "Valida els elements"
-
+  choose_folder: "(Trieu-ne una)"
+  add_item_to_folder: "Afegiu-lo a la carpeta"
+  remove_item_from_folder: "Elimineu-lo de la carpeta"
 
   # Editor sidebar
   show_all_groups: "Mostra totes les seccions"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -380,7 +380,9 @@ de:
   export_folder_csv: "Ordner als CSV exportieren"
   export_folder_raw: "Ordner als Muscat MARC exportieren"
   validate_folder: "Ordner validieren"
-
+  choose_folder: "(PLEASE CHOOSE ONE)"
+  add_item_to_folder: "ADD TO FOLDER"
+  remove_item_from_folder: "DELETE FROM FOLDER"
   
   # Editor sidebar
   show_all_groups: "Alle Blöcke anzeigen"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -380,8 +380,10 @@ en:
   export_folder_csv: "Export Folder as CSV"
   export_folder_raw: "Export Folder as Muscat MARC"
   validate_folder: "Validate items"
+  choose_folder: "(Please choose one)"
+  add_item_to_folder: "Add to folder"
+  remove_item_from_folder: "Delete from folder"
 
-  
   # Editor sidebar
   show_all_groups: "Show all sections"
   show_preview: "Show preview"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -381,7 +381,10 @@ es:
   export_folder_csv: "Exportar la carpeta en formato CSV"
   export_folder_raw: "Exportar la carpeta en formato Muscat MARC"
   validate_folder: "Validar la carpeta"
-  
+  choose_folder: "(Escoja una)"
+  add_item_to_folder: "Añadir a la carpeta"
+  remove_item_from_folder: "Quitar de la carpeta"
+
   # Editor sidebar
   show_all_groups: "Mostrar todas las secciones"
   show_preview: "Mostrar vista preliminar"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -381,7 +381,9 @@ fr:
   export_folder_csv: "Exporter le dossier en CSV"
   export_folder_raw: "Exporter le dossier en Muscat MARC"
   validate_folder: "Valider le dossier"
-
+  choose_folder: "(PLEASE CHOOSE ONE)"
+  add_item_to_folder: "ADD TO FOLDER"
+  remove_item_from_folder: "DELETE FROM FOLDER"
   
   # Editor sidebar
   show_all_groups: "Afficher tous les groupes"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -385,8 +385,9 @@ it:
   export_folder_csv: "Esporta la cartella in CSV"
   export_folder_raw: "Esporta la cartella come Muscat MARC"
   validate_folder: "Valida cartella"
-
-
+  choose_folder: "(PLEASE CHOOSE ONE)"
+  add_item_to_folder: "ADD TO FOLDER"
+  remove_item_from_folder: "DELETE FROM FOLDER"
   
   # Editor sidebar
   show_all_groups: "Mostra tutti i gruppi"

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -381,7 +381,9 @@ pl:
   export_folder_csv: Wyeksportuj folder jako CSV
   export_folder_raw: Wyeksportuj folder jako Muscat MARC
   validate_folder: Zatwierdź pozycje
-
+  choose_folder: "(PLEASE CHOOSE ONE)"
+  add_item_to_folder: "ADD TO FOLDER"
+  remove_item_from_folder: "DELETE FROM FOLDER"
   
   # Editor sidebar
   show_all_groups: Pokaż wszystkie sekcje

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -377,7 +377,10 @@ pt:
   export_folder_csv: "Exportar a pasta em CSV"
   export_folder_raw: "Exportar a pasta em Muscat MARC"
   validate_folder: "Validar pasta"
-  
+  choose_folder: "(PLEASE CHOOSE ONE)"
+  add_item_to_folder: "ADD TO FOLDER"
+  remove_item_from_folder: "DELETE FROM FOLDER"
+
   # Editor sidebar
   show_all_groups: "Mostrar todas as seções"
   show_preview: "Mostrar previsualização"

--- a/lib/folder_controller_actions.rb
+++ b/lib/folder_controller_actions.rb
@@ -189,8 +189,52 @@ module FolderControllerActions
       
       @items_count = results.total_entries
       @save_path = send(link_function)
-    end 
-     
-  end
+    end
+
+    dsl.member_action :remove_item_from_folder, :method => :delete do
+      folder_id = params.permit(:folder_id)[:folder_id]
+      item_id = params.permit(:id)[:id]
+      if !folder_id
+        redirect_to resource_path(item_id), alert: "No Folder selected"
+      else
+        begin
+          f = Folder.find(folder_id)
+          if cannot?(:manage, f)
+            redirect_to resource_path(item_id), alert: "You are not authorized to remove items from #{f.name} #{f.id}"
+          else
+            f.remove_items([item_id])
+            redirect_to resource_path(item_id), notice: "Removed 1 element from folder #{f.name} #{f.id}"
+          end
+        rescue ActiveRecord::RecordNotFound
+          redirect_to collection_path, alert: "Folder #{folder_id} does not exist"
+        end
+      end
+    end
     
+    dsl.member_action :add_item_to_folder, method: :post do
+      folder_id = params.permit(:folder_id)[:folder_id]
+      model = params.permit(:model)[:model]
+      item_id = params.permit(:item_id)[:item_id]
+      item = model.constantize.find(item_id)
+      if !folder_id
+        redirect_to resource_path(item_id), alert: "No Folder selected"
+      else
+        begin
+          f = Folder.find(folder_id)
+          if cannot?(:manage, f)
+            redirect_to resource_path(item_id), alert: "You are not authorized to remove items from #{f.name} #{f.id}"
+          else
+            f.add_items([item])
+            f.reload
+            f2 = Folder.find(f.id)
+            Sunspot.index f2.folder_items
+            Sunspot.commit
+            redirect_to resource_path(item), notice: I18n.t(:added, scope: :folders, name: f.name, count: 1)
+          end
+        rescue ActiveRecord::RecordNotFound
+          redirect_to collection_path, alert: "Folder #{folder_id} does not exist"
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Currently the only way to add items to folders is via a batch selection form a list created in the list view.  This patch allows to add and remove them from the full record view.  Closes #931.

This second version unifies in a single (and hopefully complete) commit and replaces #1388.

Thanks to @ivan-mr from @CodiTramuntana for his help finding a way of doing it following the Rails conventions.