### PR TITLE
Add DEL acronym for deleted records, unify translation files

### DIFF
--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -868,26 +868,3 @@ ca:
   blacklight_advanced_search:
     form:
       start_over: "Torna a l'inici"
-
-
-######################################################################################################
-# Record types, English only
-
-  record_types_codes:
-    "0": "UNK"
-    "1": "COL"
-    "2": "MSR"
-    "3": "SUB"
-    "4": "LSR"
-    "5": "LED"
-    "6": "TSR"
-    "7": "TED"
-    "8": "EDT"
-    "9": "LEC"
-    "10": "TEC"
-    "11": "CMP"
-
-  status_codes:
-    published: "PUB"
-    inprogress: "UNP"
-    deprecated: "DEP"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -896,3 +896,4 @@ en:
     published: "PUB"
     inprogress: "UNP"
     deprecated: "DEP"
+    deleted: "DEL"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -855,23 +855,3 @@ es:
     application_name: 'Muscat'
     header_links:
       logout: 'Cerrar sesión'
-      
- 
-######################################################################################################
-# Record types, English only
-      
-  record_types_codes:
-    "0": "UNK"
-    "1": "COL"
-    "2": "MMS"
-    "3": "MPR"
-    "4": "LMS"
-    "5": "LPR"
-    "6": "TMS"
-    "7": "TPR"
-    "8": "CVT"
-    
-  status_codes:
-    published: "PUB"
-    inprogress: "INP"
-

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -866,27 +866,3 @@ pl:
   blacklight_advanced_search:
     form:
       start_over: Zacznij od nowa
-      
- 
-######################################################################################################
-# Record types, English only
-      
-  record_types_codes:
-    "0": UNK
-    "1": COL
-    "2": MSR
-    "3": SUB
-    "4": LSR
-    "5": LED
-    "6": TSR
-    "7": TED
-    "8": EDT
-    "9": LEC
-    "10": TEC
-    "11": CMP
-    
-  status_codes:
-    published: PUB
-    inprogress: UNP
-    deprecated: DEP
-

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -851,25 +851,3 @@ pt:
     application_name: 'Muscat'
     header_links:
       logout: 'Logout'
-      
- 
-######################################################################################################
-# Record types, English only
-      
-  record_types_codes:
-    "0": "UNK"
-    "1": "COL"
-    "2": "MSR"
-    "3": "SUB"
-    "4": "LSR"
-    "5": "LEC"
-    "6": "TSR"
-    "7": "TEC"
-    "8": "EDT"
-    "11": "CMP"
-    
-  status_codes:
-    published: "PUB"
-    inprogress: "UNP"
-    deprecated: "DEP"
-


### PR DESCRIPTION
Deleted records did not have a translation acronym, and some newer translation files do have translations for status codes, although they are not used.  Remove them.

Fixes #1441