### PR TITLE
Fix sru sigla search

### DIFF
--- a/config/sru/service.config.yml
+++ b/config/sru/service.config.yml
@@ -105,6 +105,9 @@ index:
     solr: 700a
     type: text
   rism.librarySiglum:
+    solr: siglum_order
+    type: s
+  rism.libSiglum:
     solr: lib_siglum_order
     type: s
   rism.libraryCountry:


### PR DESCRIPTION
since we have some "lib_siglum_order" and "siglum_order" confusion in the index config, this one brings back the old one to enable sru sigla search again. It's really only a hot fix