### PR TITLE
Move current filter information at top of sidebar

### DIFF
--- a/vendor/assets/stylesheets/muscat.scss
+++ b/vendor/assets/stylesheets/muscat.scss
@@ -355,3 +355,11 @@ a.button-link {
   color: white;
   text-decoration: none;
 }
+
+body.index #sidebar {
+    display: flex;
+    flex-direction: column;
+    #search_status_sidebar_section { order: 1; }
+    #filters_sidebar_section { order: 2; }
+    #actions_sidebar_section { order: 3; }
+}


### PR DESCRIPTION
Muscat remembers search filters until they are explicity cleared, and that confuses users because the list of records doesn't match with what is expected.  Move the the information box to the top of the sidebar so it is obvious that there are filters active.

Thanks to @ivan-mr from @CodiTramuntana for finding a css-only solution.

Closes #1251