### PR TITLE
Added work abilities for person_editors

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -21,7 +21,7 @@ class Ability
 
     elsif user.has_role?(:editor)
       if user.has_role?(:person_editor)
-        can [:read, :create, :update, :destroy], [DigitalObject, DigitalObjectLink, Publication, Institution, LiturgicalFeast, Person, Place, StandardTerm, StandardTitle, Source, WorkNode, Holding]
+        can [:read, :create, :update, :destroy], [DigitalObject, DigitalObjectLink, Publication, Institution, LiturgicalFeast, Person, Place, StandardTerm, StandardTitle, Source, Work, WorkNode, Holding]
       elsif user.has_role?(:junior_editor)
         can [:read, :create, :update], [DigitalObject, DigitalObjectLink, Publication, Institution, LiturgicalFeast, Person, Place, StandardTerm, StandardTitle, Source, WorkNode, Holding]
       else


### PR DESCRIPTION
Since person_editors are not able to edit works, they can't change the connections (and delete the person). This fixes it.