### PR TITLE
Display subfield in Marc editor

### DIFF
--- a/lib/editor_configuration.rb
+++ b/lib/editor_configuration.rb
@@ -136,6 +136,7 @@ class EditorConfiguration
         label = I18n.t(labels_config[id][:fields][sub_id][:label], :locale => :en)  + " [translation missing]"
       end
 
+      label = "#{label} ($#{sub_id})" if edit
       return label
     end
     # if nothing found


### PR DESCRIPTION
When cataloging Marc records, the Marc tag number is shown (ex: 100), but not the subfield (ex: $a).  This information is useful to understand which value has to be filled in, and to find documentation and/or examples.

This patch adds it between parenthesis after its name, like the tag.