### PR TITLE
Update PublicationLabels.yml

### DIFF
--- a/config/editor_profiles/default/configurations/PublicationLabels.yml
+++ b/config/editor_profiles/default/configurations/PublicationLabels.yml
@@ -44,7 +44,7 @@
 '100':
   fields:
     a:
-      label: records.author
+      label: records.name
     d:
       label: records.life_dates
   label: records.author
@@ -134,7 +134,7 @@
     '4':
       label: records.function
     a:
-      label: records.person
+      label: records.name
   label: records.additional_personal_name_lit
 '710':
   fields:


### PR DESCRIPTION
Changes to labels (keys) in Secondary Literature:
- 100$a change `Author` to `Name` to match 100$a in Sources
- 700$a: change `Person` to `Name` to match 100$a in Sources (and Secondary Literature)