### PR TITLE
Update WorkLabels.yml

### DIFF
--- a/config/editor_profiles/default/configurations/WorkLabels.yml
+++ b/config/editor_profiles/default/configurations/WorkLabels.yml
@@ -77,7 +77,7 @@
     a:
       label: records.composer
     d:
-      label: records.years_birth_death
+      label: records.life_dates
     m:
       label: records.scoring_summary
     n:


### PR DESCRIPTION
Change 100$d key (label) from `Years of birth and death` to `Life dates` to align with Sources and also Personal names as described in https://github.com/rism-digital/muscat/pull/1512.