### PR TITLE
Renaming 520 in Secondary Literature

### DIFF
--- a/config/editor_profiles/default/configurations/PublicationLabels.yml
+++ b/config/editor_profiles/default/configurations/PublicationLabels.yml
@@ -104,8 +104,8 @@
 '520':
   fields:
     a:
-      label: records.contents_note
-  label: records.contents_note
+      label: records.dates_of_publication
+  label: records.dates_of_publication
 '599':
   fields:
     a:


### PR DESCRIPTION
We had a field in Kallisto to record dates of publication for a journal (to clarify: beginning and end dates of a serial publication). This is in Muscat as 520 but is labeled `Contents note`. This correction renames the field to `Dates of publication` (following the new key added in https://github.com/rism-digital/translations/pull/124).