### PR TITLE
Update Muscat saml SSO authentication to Rails 7

### DIFF
--- a/config/sample_application.rb
+++ b/config/sample_application.rb
@@ -187,6 +187,15 @@ module Muscat
     
     # See what was loaded
     #Rails.autoloaders.log!
+
+    overrides = "#{Rails.root}/app/overrides"
+    Rails.autoloaders.main.ignore(overrides)
+
+    config.to_prepare do
+      Dir.glob("#{overrides}/**/*_override.rb").sort.each do |override|
+        load override
+      end
+    end
   end
 end
 

--- a/lib/generators/muscat/install_saml_generator.rb
+++ b/lib/generators/muscat/install_saml_generator.rb
@@ -17,6 +17,10 @@ module Muscat
       copy_file "activeadmin_devise_sessions_new.html.erb", "app/views/active_admin/devise/sessions/new.html.erb"
     end
 
+    def copy_override
+      copy_file "saml_sessions_controller_override.rb", "app/overrides/controllers/devise/saml_sessions_controller_override.rb"
+    end
+
     def copy_initializer
       copy_file "devise_saml_authenticatable.rb", "config/initializers/devise_saml_authenticatable.rb"
     end

--- a/lib/generators/muscat/templates/devise_saml_authenticatable.rb
+++ b/lib/generators/muscat/templates/devise_saml_authenticatable.rb
@@ -1,14 +1,5 @@
 # Uncomment this file when using SAML after copying it in the appropriate location
 =begin
-Devise::SamlSessionsController.class_eval do
-  after_action :store_winning_strategy, only: :create
-
-  private
-
-  def store_winning_strategy
-    warden.session(:user)[:strategy] = warden.winning_strategies[:user].class.name.demodulize.underscore.to_sym
-  end
-end
 
 Devise.saml_update_resource_hook= Proc.new do |user, saml_response, auth_value|
   user.user_create_strategy= :saml_authenticatable

--- a/lib/generators/muscat/templates/saml_sessions_controller_override.rb
+++ b/lib/generators/muscat/templates/saml_sessions_controller_override.rb
@@ -1,0 +1,9 @@
+Devise::SamlSessionsController.class_eval do
+  after_action :store_winning_strategy, only: :create
+
+  private
+
+  def store_winning_strategy
+    warden.session(:user)[:strategy] = warden.winning_strategies[:user].class.name.demodulize.underscore.to_sym
+  end
+end


### PR DESCRIPTION
New Rails 7 loader (zeitwerk) conflicts with previous setup, and it does not load the libraries in the order they used to.  Change it slightly, and add an override rule in config/sample_application.rb

All the hard work, and thus, the merit, goes to @ivan-mr from @CodiTramuntana.