### PR TITLE
Add missing user help files for Catalan and Spanish

### DIFF
--- a/app/views/admin/users/_help_text.ca.md
+++ b/app/views/admin/users/_help_text.ca.md
@@ -1,0 +1,135 @@
+## Com funcionen les notificacions
+
+Es poden crear notificacions per rebre alertes per correu quan es creïn o editin registres que corresponguin amb les vostres regles de cerca.
+
+Entreu aquestes regles a la casella de les notificacions.
+
+L'estructura de cada regla es: nom del camp, dos punts, i el terme de cerca. Fixeu-vos que no hi ha cap espai després dels dos punts. En aquest exemple, es generarà una notificació cada cop que es desi un registre amb la sigla de la biblioteca CH:BE1.
+
+```
+lib_siglum:CH-BEl
+```
+
+Entreu cada regla en una línia diferent:
+
+```
+lib_siglum:CH-BEl
+composer:Bach
+```
+
+Aquesta vol dir que rebreu una notificació per a cada registre de font que tingui com a sigla de biblioteca CH-BE1, i una altra per a cada registre de font del compositor Bach.
+
+Podeu combinar regles posant-les en una mateixa línia, separades per un espai:
+
+```
+lib_siglum:CH* composer:Bach*
+```
+
+Aquesta us trobarà canvis a tots els registres de font que tinguin una sigla de biblioteca que comenci per CH i un compositor que comenci per Bach.
+
+Les regles es poden repetir a la llista de notificacions, però s'avaluaran per separat. Per exemple:
+
+```
+lib_siglum:CH* composer:Bach*
+lib_siglum:CH*
+```
+
+En aquest cas, rebreu notificacions per a tots els registres de font de CH que tinguin com a compositor Bach, i a més a més, notificacions per a tots els registres de font de CH:
+
+### Categories de cerca
+
+Per defecte, les regles s'apliquen als registres de font. Però també en podeu crear per a registres d'autoritat, especificant-ho al començament de la regla i seguida d'un espai, com ara:
+
+```
+work composer:Bach*
+institution name:British*
+```
+
+Cada regla només pot cercar una categoria.
+
+### Asteriscs i espais
+
+Les regles poden incloure asteriscs per permetre truncaments:
+
+```
+lib_siglum:CH*
+```
+
+Aquesta crea una notificació per a cada registre de font en què la sigla de la biblioteca comenci per CH.
+
+Els termes de cerca que tinguin espais s'han de posar entre cometes:
+
+```
+composer:"Bach, Johann Sebastian";
+```
+
+o
+
+```
+composer:"Bach, Johann*";
+```
+
+Sense cometes, només es cercaria la primera paraula, i les altres s'ignorarien. Fixeu-vos que el nom del camp no les porta, les cometes.
+
+### Catetories i camps disponibles:
+
+#### Registres de font (valor per defecte)
+
+* **lib\_siglum** _Sigla de biblioteca (852 $a)_
+* **shelf\_mark** _Topogràfic (852 $c)_
+* **composer** _Compositor/autor (100 $a)_
+* **std\_title** _Títol uniforme (240 $a)_
+* **title** _Títol propi (245 $a)_
+* **record\_type** _tipus de plantilla_:
+    * collection (registre mare per a manuscrits, llibrets o tractats)
+    * source (manuscrits, llevat dels de col·leccions)
+    * edition (edicions de música impresa, menys les entrades individuals)
+    * edition\_content (entrades individuals d'una edició impresa)
+    * libretto\_source (llibrets manuscrits, menys els registres de col·lecció)
+    * libretto\_edition (llibrets impresos, llevat les entrades individuals)
+    * libretto\_edition\_content (entrades individuals en llibrets impresos)
+    * theoretica\_source (tractats manuscrits, llevat dels registres de col·lecció)
+    * theoretica\_edition (tractats impresos, menys les entrades individuals) 
+    * theoretica\_edition\_content (entrades individuals en un tractat imprès)
+    * composite\_volume
+
+Exemple:
+
+```
+record_type:edition lib_siglum:CH* composer:Bach* std_title:"6 Fugues";
+```
+
+### Obras
+
+- **composer** _Nom del compositor (100 $a)_
+- **title** _Títol de la obra (100 $t)_
+
+Exemple:
+
+```
+work composer: "Bach, Albert*"
+```
+
+### Institucions
+
+- **name** _Forma autoritzada del nom de la institució (110 $a)_
+- **place** _Ciutat de la institució (110 $c)_
+- **siglum** _Sigla de la institució (110 $g)_
+- **address** _Adreça de la institució (371 $a)_
+- **alternates** _Noms alternatius (510 or 410)_
+- **notes** _Qualsevol paraula del camp de notes (680 $a)_
+
+Exemple:
+
+```
+institution name:Universitätsbibliothek*
+```
+
+### Freqüència de les notificacions
+
+En el desplegable _Freqüència de les notificacions_ podeu triar la freqüència de cada quan voleu que s'us notifiqui:
+
+- **cada cop** Enviar una notificació cada cop que es desa un registre (amb un període de gràcia d'una hora quan un registre es desa més d'un cop per la mateixa persona).
+- **cada dia** La llista dels registres modificats s'envia un cop al dia.
+- **cada setmana** La llista dels registres modificats s'envia un cop a la setmana.
+- **desactivades** Les notifications estan desactivades.

--- a/app/views/admin/users/_help_text.es.md
+++ b/app/views/admin/users/_help_text.es.md
@@ -1,0 +1,135 @@
+## Cóm funcionan las notificaciones
+
+Se pueden crear notificaciones para recibir alertas por correo cuando se crean o editan registros que correspongan con sus reglas de búsqueda.
+
+Introduzca estas reglas en el campo de notificaciones.
+
+La estructura de cada regla es: nombre del campo, dos puntos, y el término de búsqueda. Vigile que no haya ningún espacio después de los dos puntos. En este ejemplo, se generará una notificación cada vez que es guarde un registro con la sigla de la biblioteca CH:BE1.
+
+```
+lib_siglum:CH-BEl
+```
+
+Introduzca cada regla en una linea diferente:
+
+```
+lib_siglum:CH-BEl
+composer:Bach
+```
+
+Ésta implica que recibirá una notificación por cada registro de fuentes que tenga como sigla de biblioteca CH-BE1, y oltra para cada registro de fuentes del compositor Bach.
+
+Puede combinar reglas escribiéndolas en una misma linia, separadas per un espacio:
+
+```
+lib_siglum:CH* composer:Bach*
+```
+
+Ésta encontrará cambios en todos los registros de fonte que tengan una sigla de biblioteca que empiece por CH y un compositor que empiece por Bach.
+
+Las reglas se pueden repetir en la lista de notificaciones, pero se evaluarán por separado. Por ejemplo:
+
+```
+lib_siglum:CH* composer:Bach*
+lib_siglum:CH*
+```
+
+En este caso, recibirá notificaciones para todos los registros de fuentes de CH que tengan como compositor Bach, y, además, notificaciones para todos los registros de funete de CH:
+
+### Categorías de búsqueda
+
+Por defecto, las reglas se aplican a los registros de fuentes. Pero también se puden crear para registros de autoridad, especificándolo al principio de la regla y seguida de un espacio, por ejemplo:
+
+```
+work composer:Bach*
+institution name:British*
+```
+
+Cada regla sólo puede buscar una categoría.
+
+### Asteriscos y espacios
+
+Las reglas pueden incluir asteriscos para permitir truncamientos:
+
+```
+lib_siglum:CH*
+```
+
+Esta regla crea una notificación para cada registro de fuente en la que la sigla de la biblioteca comience por CH.
+
+Los términos de búsqueda que tengan espacios se deben escribir entre comillas.
+
+```
+composer:"Bach, Johann Sebastian";
+```
+
+o
+
+```
+composer:"Bach, Johann*";
+```
+
+Si no hubiera comillas, sólo se buscaría la primera palabra, y las demás serían ingoradas. Tenga en cuenta que el nombre del campo no está incluido en las comillas.
+
+### Catetorías y camps disponibles:
+
+#### Registros de fuente (valor por defecto)
+
+* **lib\_siglum** _Sigla de biblioteca (852 $a)_
+* **shelf\_mark** _Topográfico (852 $c)_
+* **composer** _Compositor/autor (100 $a)_
+* **std\_title** _Título uniforme (240 $a)_
+* **title** _Título propio (245 $a)_
+* **record\_type** _tipo de plantilla_:
+    * collection (registro madre para manuscrits, libretos o tratados)
+    * source (manuscritos, menos los de colección)
+    * edition (ediciones de música impresa, menos las entradas individuales)
+    * edition\_content (entradas individuales de una edición impresa)
+    * libretto\_source (libretos manuscritos, menos los registres de colección)
+    * libretto\_edition (libretos impresos, menos las entradas individuales)
+    * libretto\_edition\_content (entradas individuales en libretos impresos)
+    * theoretica\_source (tratados manuscritos, excepto los registres de colección)
+    * theoretica\_edition (tratados impresos, menos las entrades individuales) 
+    * theoretica\_edition\_content (entradas individuales en un tratado impreso)
+    * composite\_volume
+
+Ejemplo:
+
+```
+record_type:edition lib_siglum:CH* composer:Bach* std_title:"6 Fugues";
+```
+
+### Obras
+
+- **composer** _Nombre del compositor (100 $a)_
+- **title** _Título de la obra (100 $t)_
+
+Ejemplo:
+
+```
+work composer: "Bach, Albert*"
+```
+
+### Instituciones
+
+- **name** _Forma autorizada del nombre de la institución (110 $a)_
+- **place** _Ciudad de la institución (110 $c)_
+- **siglum** _Sigla de la institución (110 $g)_
+- **address** _Dirección de la institución (371 $a)_
+- **alternates** _Nombres alternativos (510 or 410)_
+- **notes** _Cualquer palabra en el campo de notas (680 $a)_
+
+Ejemplo:
+
+```
+institution name:Universitätsbibliothek*
+```
+
+### Cadencia de las notificaciones
+
+En el desplegable _Cadencia de las notificaciones_ puede escoger la cadencia respecto a cuado prefiere que se le notifique:
+
+- **cada vez** Enviar una notificación cada vez que es guarde un registre (con un período de gracia de una hora cuando un registro es guarda más de una vez por la misma persona).
+- **cada dia** La lista de los registres modificados se envía una vez al día.
+- **cada semana** La llista de los registros modificados se envía un vez a la semana.
+- **desactivades** Las notificationes están desactivadas.


### PR DESCRIPTION
Without those files, it is not possible to edit user alerts if locale is set to Catalan or Spanish, as the application fails due to a missing help file.