### PR TITLE
Update InstitutionLabels.yml

### DIFF
--- a/config/editor_profiles/default/configurations/InstitutionLabels.yml
+++ b/config/editor_profiles/default/configurations/InstitutionLabels.yml
@@ -196,10 +196,10 @@
 '856':
   fields:
     u:
-      label: records.online_finding_aids
+      label: records.external_resource_url
     z:
       label: records.note_external_resource
-  label: records.online_finding_aids
+  label: records.external_resource
 Archive:
   label: records.archive
 Bookseller:


### PR DESCRIPTION
In Institutions we'd like to move away from the 856 label `Online finding aids` and expand the scope to include URLs of any kind. This change makes the 856 align with the labels across Muscat.