### PR TITLE
Update PublicationFormOptions.yml

### DIFF
--- a/config/editor_profiles/default/configurations/PublicationFormOptions.yml
+++ b/config/editor_profiles/default/configurations/PublicationFormOptions.yml
@@ -144,7 +144,6 @@
       - "XA-ES"
       - "XA-SE"
       - "XA-CH"
-      - "XA-CH-VD"
       - "XB-SY"
       - "XD-TT"
       - "XB-TR"


### PR DESCRIPTION
`Switzerland: Vaud` is appearing as a country in 044 in Publications but we don't need the regions in this field, just the main country (already present as `XA-CH`).

![image](https://github.com/rism-digital/muscat/assets/18663291/7a87fb0c-25ac-4f8a-b100-f93121ae68d1)

Removing `XA-CH-VD` from the list.