### PR TITLE
Add display_name to people

### DIFF
--- a/db/migrate/20240521090418_add_display_name_to_people.rb
+++ b/db/migrate/20240521090418_add_display_name_to_people.rb
@@ -1,0 +1,5 @@
+class AddDisplayNameToPeople < ActiveRecord::Migration[7.0]
+  def change
+    add_column :people, :display_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_14_123649) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_14_090418) do
   create_table "active_admin_comments", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.string "namespace"
     t.text "body"
@@ -261,6 +261,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_14_123649) do
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.integer "lock_version", default: 0, null: false
+    t.string "display_name"
     t.index ["full_name"], name: "index_people_on_full_name"
     t.index ["wf_stage"], name: "index_people_on_wf_stage"
   end


### PR DESCRIPTION
The commit 3ff0f26f6f5f161a764802dfc00a2e33c7f7c1ea removed full_name_d, that we have been using to create a richer display form of people (with life dates and other subfields that disambiguate similar names) for lists and autocompletions.  As requested by @xhero, this patch creates a new column named display_name for this purpose.  Its value will be generated in lib/marc_person.rb, with the goal to be generated only once, as it is used quite often, and generate it every time is costly.  I'm leaving this part for a future PR, as I need to make our usage compatible with upstream Muscat.