### PR TITLE
Update wf_owner when non-marc authority records are updated

### DIFF
--- a/app/admin/liturgical_feast.rb
+++ b/app/admin/liturgical_feast.rb
@@ -70,7 +70,7 @@ ActiveAdmin.register LiturgicalFeast do
     # redirect update failure for preserving sidebars
     def update
       update! do |success,failure|
-        success.html { redirect_to collection_path }
+        success.html { redirect_to resource_path(params[:id]) }
         failure.html { redirect_back fallback_location: root_path, flash: { :error => "#{I18n.t(:error_saving)}" } }
       end
       # Run the eventual triggers
@@ -140,6 +140,7 @@ ActiveAdmin.register LiturgicalFeast do
       row (I18n.t :filter_name) { |r| r.name }
       row (I18n.t :filter_alternate_terms) { |r| r.alternate_terms }
       row (I18n.t :filter_notes) { |r| r.notes } 
+      row (I18n.t :filter_owner) { |r| User.find_by(id: r.wf_owner).name rescue r.wf_owner }
     end
     active_admin_embedded_source_list( self, liturgical_feast, !is_selection_mode? )
 
@@ -180,6 +181,7 @@ ActiveAdmin.register LiturgicalFeast do
       f.input :alternate_terms, :label => (I18n.t :filter_alternate_terms)
       f.input :notes, :label => (I18n.t :filter_notes)
       f.input :wf_stage, :label => (I18n.t :filter_wf_stage)
+      f.input :wf_owner, :input_html => { :value => current_user.id }, :as => :hidden
       f.input :lock_version, :as => :hidden
     end
   end

--- a/app/admin/place.rb
+++ b/app/admin/place.rb
@@ -69,7 +69,7 @@ ActiveAdmin.register Place do
     # redirect update failure for preserving sidebars
     def update
       update! do |success,failure|
-        success.html { redirect_to collection_path }
+        success.html { redirect_to resource_path(params[:id]) }
         failure.html { redirect_back fallback_location: root_path, flash: { :error => "#{I18n.t(:error_saving)}" } }
       end
       # Run the eventual triggers
@@ -159,6 +159,7 @@ ActiveAdmin.register Place do
       row (I18n.t :filter_country) { |r| r.country }
       row (I18n.t :filter_district) { |r| r.district }    
       row (I18n.t :filter_notes) { |r| r.notes }    
+      row (I18n.t :filter_owner) { |r| User.find_by(id: r.wf_owner).name rescue r.wf_owner }
     end
 
     active_admin_embedded_source_list( self, place, !is_selection_mode? )
@@ -264,6 +265,8 @@ ActiveAdmin.register Place do
       f.input :country, :label => (I18n.t :filter_country), :as => :string # otherwise country-select assumed
       f.input :district, :label => (I18n.t :filter_district)
       f.input :notes, :label => (I18n.t :filter_notes)
+      f.input :wf_stage, :label => (I18n.t :filter_wf_stage)
+      f.input :wf_owner, :input_html => { :value => current_user.id }, :as => :hidden
       f.input :lock_version, :as => :hidden
     end
   end

--- a/app/admin/standard_term.rb
+++ b/app/admin/standard_term.rb
@@ -86,7 +86,7 @@ ActiveAdmin.register StandardTerm do
     # redirect update failure for preserving sidebars
     def update
       update! do |success,failure|
-        success.html { redirect_to collection_path }
+        success.html { redirect_to resource_path(params[:id]) }
         failure.html { redirect_back fallback_location: root_path, flash: { :error => "#{I18n.t(:error_saving)}" } }
       end
 
@@ -154,6 +154,7 @@ ActiveAdmin.register StandardTerm do
       row (I18n.t :filter_term) { |r| r.term }
       row (I18n.t :filter_alternate_terms) { |r| r.alternate_terms }
       row (I18n.t :filter_notes) { |r| r.notes }    
+      row (I18n.t :filter_owner) { |r| User.find_by(id: r.wf_owner).name rescue r.wf_owner }
     end
     active_admin_embedded_source_list( self, standard_term, !is_selection_mode? )
     
@@ -209,6 +210,7 @@ ActiveAdmin.register StandardTerm do
       f.input :alternate_terms, :label => (I18n.t :filter_alternate_terms), :input_html => { :rows => 8 }
       f.input :notes, :label => (I18n.t :filter_notes)
       f.input :wf_stage, :label => (I18n.t :filter_wf_stage)
+      f.input :wf_owner, :input_html => { :value => current_user.id }, :as => :hidden
       f.input :lock_version, :as => :hidden
     end
   end

--- a/app/admin/standard_title.rb
+++ b/app/admin/standard_title.rb
@@ -92,7 +92,7 @@ ActiveAdmin.register StandardTitle do
     # redirect update failure for preserving sidebars
     def update
       update! do |success,failure|
-        success.html { redirect_to collection_path }
+        success.html { redirect_to resource_path(params[:id]) }
         failure.html { redirect_back fallback_location: root_path, flash: { :error => "#{I18n.t(:error_saving)}" } }
       end
 
@@ -174,6 +174,7 @@ ActiveAdmin.register StandardTitle do
       row (I18n.t :filter_record_type) { |r| r.typus }
       row (I18n.t :menu_latin) { |r| r.latin }
       row (I18n.t :filter_notes) { |r| r.notes }  
+      row (I18n.t :filter_owner) { |r| User.find_by(id: r.wf_owner).name rescue r.wf_owner }
     end
     active_admin_embedded_source_list( self, standard_title, !is_selection_mode? )
 
@@ -221,6 +222,7 @@ ActiveAdmin.register StandardTitle do
       #f.input :typus, :label => (I18n.t :filter_record_type) 
       f.input :notes, :label => (I18n.t :filter_notes) 
       f.input :wf_stage, :label => (I18n.t :filter_wf_stage)
+      f.input :wf_owner, :input_html => { :value => current_user.id }, :as => :hidden
       f.input :lock_version, :as => :hidden
     end
   end


### PR DESCRIPTION
Make this field visible in the display page, and update it using current user field.  After uptading, redirect to the display page, because if redirects to the list, the modified record is lost and not easily accessible, except via the browser history.

Closes #1584