### PR TITLE
Make logs less verbose on development mode

### DIFF
--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -2,6 +2,7 @@ Delayed::Worker.destroy_failed_jobs = false
 Delayed::Worker.max_attempts = 3
 Delayed::Worker.max_run_time = 1.day
 Delayed::Worker.logger = Logger.new(File.join(Rails.root, 'log', 'delayed_job.log'))
+Delayed::Worker.sleep_delay = 30 if Rails.env.development? # To avoid verbose logs
 
 Delayed::Backend::ActiveRecord.configure do |config|
     config.reserve_sql_strategy = :default_sql # Use the conservative locking


### PR DESCRIPTION
It is difficult to find useful information in Muscat log files due to the the noise that the workers write.  Some time ago I googled around to find an easy to implement solution to this situation, as it should be common to any Rails app.  I found this one to be simple, and works very well, at least for me.