### PR TITLE
Add i18n to record actions pulldown texts

### DIFF
--- a/app/views/editor/_record_actions.html.erb
+++ b/app/views/editor/_record_actions.html.erb
@@ -16,21 +16,23 @@
 							<select id="record_status" width="100">
 								<% if @item.id == nil %>
 									<% if current_user.preference_wf_stage == "published" %>
-										<option value="published" selected="true">Published</option>
-										<option value="inprogress">Unpublished</option>
+										<option value="published" selected="true"><%=I18n.t("wf_stage.published")%></option>
+										<option value="inprogress"><%=I18n.t("wf_stage.inprogress")%></option>
 									<%else%>
-										<option value="published">Published</option>
-										<option value="inprogress" selected="true">Unpublished</option>
+										<option value="published"><%=I18n.t("wf_stage.published")%></option>
+										<option value="inprogress" selected="true"><%=I18n.t("wf_stage.inprogress")%>%</option>
 									<%end%>
 								<%else%>
 									<% if @item.wf_stage == "published" %>
-										<option value="published" selected="true">Published</option>
-										<option value="inprogress">Unpublished</option>
+										<option value="published" selected="true"><%=I18n.t("wf_stage.published")%></option>
+										<option value="inprogress"><%=I18n.t("wf_stage.inprogress")%></option>
 									<%else%>
-										<option value="published">Published</option>
-										<option value="inprogress" selected="true">Unpublished</option>
+										<option value="published"><%=I18n.t("wf_stage.published")%></option>
+										<option value="inprogress" selected="true"><%=I18n.t("wf_stage.inprogress")%></option>
 									<%end%>
 								<%end%>
+								<option value="deprecated"><%=I18n.t("wf_stage.deprecated")%></option>
+								<option value="deleted"><%=I18n.t("wf_stage.deleted")%></option>
 							</select>
 	    				</div>
 	    			</div>


### PR DESCRIPTION
Record action text was only in English, so add the i18n wrapper.  Add also the deprecated and deleted statuses, if they are also useful at RISM; otherwise, just drop both lines.