### PR TITLE
Adds 008 to the marc export

### DIFF
--- a/app/admin/institution.rb
+++ b/app/admin/institution.rb
@@ -73,7 +73,7 @@ ActiveAdmin.register Institution do
 
       respond_to do |format|
         format.html
-        format.xml { render :xml => @item.marc.to_xml({ updated_at: @item.updated_at, versions: @item.versions }) }
+        format.xml { render :xml => @item.marc.to_xml({ created_at: @item.created_at, updated_at: @item.updated_at, versions: @item.versions }) }
       end
     end
 

--- a/app/admin/person.rb
+++ b/app/admin/person.rb
@@ -94,7 +94,7 @@ ActiveAdmin.register Person do
 
       respond_to do |format|
         format.html
-        format.xml { render :xml => @item.marc.to_xml({ updated_at: @item.updated_at, versions: @item.versions }) }
+        format.xml { render :xml => @item.marc.to_xml({ created_at: @item.created_at, updated_at: @item.updated_at, versions: @item.versions }) }
       end
     end
 

--- a/app/admin/publication.rb
+++ b/app/admin/publication.rb
@@ -84,7 +84,7 @@ ActiveAdmin.register Publication do
       
       respond_to do |format|
         format.html
-        format.xml { render :xml => @item.marc.to_xml({ updated_at: @item.updated_at, versions: @item.versions }) }
+        format.xml { render :xml => @item.marc.to_xml({ created_at: @item.created_at, updated_at: @item.updated_at, versions: @item.versions }) }
       end
     end
 

--- a/app/admin/source.rb
+++ b/app/admin/source.rb
@@ -80,7 +80,7 @@ ActiveAdmin.register Source do
 
       respond_to do |format|
         format.html
-        format.xml { render :xml => @item.marc.to_xml({ updated_at: @item.updated_at, versions: @item.versions}) }
+        format.xml { render :xml => @item.marc.to_xml({ created_at: @item.created_at, updated_at: @item.updated_at, versions: @item.versions}) }
       end
     end
 

--- a/app/admin/work_node.rb
+++ b/app/admin/work_node.rb
@@ -77,7 +77,7 @@ ActiveAdmin.register WorkNode do
       
       respond_to do |format|
         format.html
-        format.xml { render :xml => @item.marc.to_xml({ updated_at: @item.updated_at, versions: @item.versions }) }
+        format.xml { render :xml => @item.marc.to_xml({ created_at: @item.created_at, updated_at: @item.updated_at, versions: @item.versions }) }
       end
     end
     

--- a/app/controllers/sru_controller.rb
+++ b/app/controllers/sru_controller.rb
@@ -36,7 +36,7 @@ class SruController < ActionController::Base
             result.hits.each_with_index do |hit, idx|
               res << "<zs:recordPacking>xml</zs:recordPacking>
                 <zs:recordData>
-              #{Nokogiri::HTML.fragment(hit.result.marc.to_xml_record({ updated_at: hit.result.updated_at, holdings: true }).to_s.html_safe).to_s}
+              #{Nokogiri::HTML.fragment(hit.result.marc.to_xml_record({ created_at: hit.result.created_at, updated_at: hit.result.updated_at, holdings: true }).to_s.html_safe).to_s}
                 </zs:recordData>
                 <zs:recordPosition>#{idx + 1}</zs:recordPosition>
                 </zs:record>"

--- a/app/views/marc/_show_raw.html.erb
+++ b/app/views/marc/_show_raw.html.erb
@@ -1,6 +1,6 @@
 <div class="panel panel_group">
 <h3>MARC21</h3>
-	<%marc = @item.marc.to_marc_external({ updated_at: @item.updated_at, versions: @item.versions }) %>
+	<%marc = @item.marc.to_marc_external({ created_at: @item.created_at, updated_at: @item.updated_at, versions: @item.versions }) %>
 	<%css_marc = marc.gsub(/(=\d{3})  /, '<br><span class="marc_tag">\1</span> ').gsub(/(\$.)/, '<span class="marc_subfield">\1</span>').html_safe %>
     
 	<div class="marc21">

--- a/app/views/sru/_result.xml.erb
+++ b/app/views/sru/_result.xml.erb
@@ -9,9 +9,9 @@
           <zs:recordData>
             <% if hit.result %>
               <% if @sru.schema == 'marc' %>
-                <%= hit.result.marc.to_xml({updated_at: hit.result.updated_at, holdings: true, collection: true, ns_name: 'marc', deprecated_ids: @sru.deprecatedIds }).html_safe %>
+                <%= hit.result.marc.to_xml({ created_at: hit.result.created_at, updated_at: hit.result.updated_at, holdings: true, collection: true, ns_name: 'marc', deprecated_ids: @sru.deprecatedIds }).html_safe %>
               <% elsif @sru.schema == 'mods'%>
-                <% xml = Nokogiri::XML(hit.result.marc.to_xml({ updated_at: hit.result.updated_at, holdings: true, collection: true })) %>
+                <% xml = Nokogiri::XML(hit.result.marc.to_xml({ created_at: hit.result.created_at, updated_at: hit.result.updated_at, holdings: true, collection: true })) %>
                 <% template =  Nokogiri::XSLT(File.read('public/xml/MARC21slim2MODS3-6.xsl')) %>
                 <% mods_record = template.transform(xml) %>
                 <% mods_record.xpath("//ns:modsCollection", "ns" => "http://www.loc.gov/mods/v3").children.first["xmlns:mods"] = "http://www.loc.gov/mods/v3" %>

--- a/lib/marc.rb
+++ b/lib/marc.rb
@@ -103,7 +103,7 @@ class Marc
     # adding created at 008
     if created_at 
       created = created_at.strftime("%y%m%d")
-      _008_content = "#{created}##################################"
+      _008_content = "#{created}||||||||||||||||||||||||||||||||||"
       tag_008 = MarcNode.new(@model, "008", _008_content, nil)
       @root.children.insert(get_insert_position("008"), tag_008)
     end

--- a/lib/marc_gnd_work.rb
+++ b/lib/marc_gnd_work.rb
@@ -3,8 +3,8 @@ class MarcGndWork < Marc
     super(model, source)
   end
 
-  def to_external(updated_at = nil, versions = nil, holdings = false, deprecated_ids = true)
-    super(updated_at, nil, holdings)
+  def to_external(created_at = nil, updated_at = nil, versions = nil, holdings = false, deprecated_ids = true)
+    super(created_at, updated_at, nil, holdings)
     # nothing specific to do - this is used ony for deprecating works
   end
   

--- a/lib/marc_institution.rb
+++ b/lib/marc_institution.rb
@@ -66,24 +66,9 @@ class MarcInstitution < Marc
     end
   end
   def to_external(created_at = nil, updated_at = nil, versions = nil, holdings = false, deprecated_ids = true)
+    super(created_at, updated_at, versions)
     parent_object = Institution.find(get_id)
-    # cataloguing agency
-    _003_tag = first_occurance("003")
-    if !_003_tag
-      agency = MarcNode.new(@model, "003", RISM::AGENCY, "")
-      @root.children.insert(get_insert_position("003"), agency)
-    end
-
-    if updated_at
-      last_transcation = updated_at.strftime("%Y%m%d%H%M%S") + ".0"
-      # 005 should not be there, if it is avoid duplicates
-      _005_tag = first_occurance("005")
-      if !_005_tag
-        @root.children.insert(get_insert_position("003"),
-            MarcNode.new(@model, "005", last_transcation, nil))
-      end
-    end
-
+    
     by_tags("667").each {|t| t.destroy_yourself}
 
     source_size = parent_object.referring_sources.where(wf_stage: 1).size + parent_object.holdings.size rescue 0

--- a/lib/marc_institution.rb
+++ b/lib/marc_institution.rb
@@ -65,7 +65,7 @@ class MarcInstitution < Marc
       end
     end
   end
-  def to_external(updated_at = nil, versions = nil, holdings = false, deprecated_ids = true)
+  def to_external(created_at = nil, updated_at = nil, versions = nil, holdings = false, deprecated_ids = true)
     parent_object = Institution.find(get_id)
     # cataloguing agency
     _003_tag = first_occurance("003")

--- a/lib/marc_person.rb
+++ b/lib/marc_person.rb
@@ -69,7 +69,7 @@ class MarcPerson < Marc
   end
 
   
-  def to_external(updated_at = nil, versions = nil, holdings = false, deprecated_ids = true)
+  def to_external(created_at = nil, updated_at = nil, versions = nil, holdings = false, deprecated_ids = true)
     # cataloguing agency
     _003_tag = first_occurance("003")
     if !_003_tag

--- a/lib/marc_person.rb
+++ b/lib/marc_person.rb
@@ -70,22 +70,8 @@ class MarcPerson < Marc
 
   
   def to_external(created_at = nil, updated_at = nil, versions = nil, holdings = false, deprecated_ids = true)
-    # cataloguing agency
-    _003_tag = first_occurance("003")
-    if !_003_tag
-      agency = MarcNode.new(@model, "003", RISM::AGENCY, "")
-      @root.children.insert(get_insert_position("003"), agency)
-    end
-  
-    if updated_at
-      last_transcation = updated_at.strftime("%Y%m%d%H%M%S") + ".0"
-      # 005 should not be there, if it is avoid duplicates
-      _005_tag = first_occurance("005")
-      if !_005_tag
-        @root.children.insert(get_insert_position("003"),
-            MarcNode.new(@model, "005", last_transcation, nil))
-      end
-    end
+    super(created_at, updated_at, versions)
+    
     by_tags("667").each {|t| t.destroy_yourself}
   end
  

--- a/lib/marc_source.rb
+++ b/lib/marc_source.rb
@@ -359,8 +359,8 @@ class MarcSource < Marc
     end
   end
   
-  def to_external(updated_at = nil, versions = nil, holdings = true, deprecated_ids = true)
-    super(updated_at, versions)
+  def to_external(created_at = nil, updated_at = nil, versions = nil, holdings = true, deprecated_ids = true)
+    super(created_at, updated_at, versions)
     parent_object = Source.find(get_id)
     # See #933, supersedes #176
     # Step 1, make leader

--- a/lib/marc_work.rb
+++ b/lib/marc_work.rb
@@ -73,7 +73,7 @@ class MarcWork < Marc
   end
 
   # Make sure we do not use the default to_external
-  def to_external(updated_at = nil, versions = nil, holdings = false, deprecated_ids = true)
+  def to_external(created_at = nil, updated_at = nil, versions = nil, holdings = false, deprecated_ids = true)
   end
 
 end

--- a/lib/marc_work_node.rb
+++ b/lib/marc_work_node.rb
@@ -47,8 +47,8 @@ class MarcWorkNode < Marc
     tag100.add_at(MarcNode.new("work_node", "0", person.id, nil), 0)
   end
 
-  def to_external(updated_at = nil, versions = nil, holdings = false, deprecated_ids = true)
-    super(updated_at, nil, holdings)
+  def to_external(created_at = nil, updated_at = nil, versions = nil, holdings = false, deprecated_ids = true)
+    super(created_at, updated_at, nil, holdings)
     # nothing specific to do - this is used ony for deprecating works
   end
   


### PR DESCRIPTION
* Adds a `created_at` parameter to the calling functions
* Remove duplicating code
* Change `#` to `|` following marc specifications

```
=001 41010233
=003 DE-633
=005 20190303095544.0
=008 180108||||||||||||||||||||||||||||||||||
=040 ##$aDE-633$bger$cDE-633
=042 ##$anot individualized
=100 1#$aAachen church copyist 1$d19.sc
=375 ##$aunknown
=550 ##$aCopyist 
```