### PR TITLE
Pregenerate and use a person display_name to disambiguate similar ones

### DIFF
--- a/app/admin/person.rb
+++ b/app/admin/person.rb
@@ -36,7 +36,7 @@ ActiveAdmin.register Person do
   # temporarily allow all parameters
   controller do
 
-    autocomplete :person, :full_name, :display_value => :autocomplete_label , :extra_data => [:life_dates]
+    autocomplete :person, :full_name, :display_value => :autocomplete_label , :extra_data => [:display_name, :life_dates]
     autocomplete :person, "550a_sms", :solr => true, :display_value => :label
 
     after_destroy :check_model_errors

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -311,6 +311,7 @@ class Person < ApplicationRecord
     
     # varia
     self.gender, self.birth_place, self.source = marc.get_gender_birth_place_and_source
+    self.display_name = marc.get_display_name
 
     self.marc_source = self.marc.to_marc
   end
@@ -325,15 +326,7 @@ class Person < ApplicationRecord
   end
   
   def autocomplete_label
-    #1540, does this slow things up too much?
-    #Since the autocomplete only gets the minimum fields
-    pp = Person.find(id)
-    pp.marc.load_source false
-    person_function = pp.marc.first_occurance("100", "c")
-
-    "#{full_name}" + 
-      (person_function && person_function.content && !person_function.content.empty? ? " (#{person_function.content})" : "") + 
-      (life_dates && !life_dates.empty? ? "  - #{life_dates}" : "")
+    display_name
   end
 
   ransacker :"100d", proc{ |v| } do |parent| parent.table[:id] end

--- a/lib/marc_person.rb
+++ b/lib/marc_person.rb
@@ -22,6 +22,25 @@ class MarcPerson < Marc
     [full_name, dates]
   end
   
+  def get_display_name
+    # Person name as displayed in people lists and autocomplete fields
+    display_name = ""
+
+    if node = first_occurance("100", "a")
+      display_name = node.content
+    end
+
+    if node = first_occurance("100", "c")
+      display_name += " (#{node.content})"
+    end
+
+    if node = first_occurance("100", "d")
+      display_name += " - #{node.content}"
+    end
+
+    display_name.truncate(256)
+  end
+
   def get_alternate_names_and_dates
     names = []
     dates = nil


### PR DESCRIPTION
When different people share the same or similar name, other fields are used to distinguish them, like life dates.  In Muscat, this richer form of name is used, at least, in autocomplete forms, although it could be used on other places.  Instead of building it each time, create it once and store it in db.