### PR TITLE
Remove obsolete utf8=✓ from url parameters

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -100,4 +100,6 @@ Rails.application.configure do
 
   config.logger = ActiveSupport::Logger.new("log/#{Rails.env}.log", 10, 10485760)
 
+  # Do not add obsolete utf8=✓ to url parameters (default setting since Rails 6)
+  config.action_view.default_enforce_utf8 = false
 end


### PR DESCRIPTION
Since Rails 6 (August 2019), it is considered that it is no longer necessary to check for obsolete browsers, so remove it also from Muscat.  This creates shorter and cleaner urls.  See
https://guides.rubyonrails.org/6_0_release_notes.html#action-view-notable-changes