### PR TITLE
Optimize space in users list

### DIFF
--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -61,14 +61,14 @@ ActiveAdmin.register User do
     selectable_column
     column "Id", sortable: :id do |user|
       if can?(:edit, user)
-        link_to user.id, edit_admin_user_path(user)
+        link_to user.id, edit_admin_user_path(user), { title: I18n.t(:edit) }
       else
         user.id
       end
     end
     column :username
     column :name do |user|
-      link_to user.name, admin_user_path(user)
+      link_to user.name, admin_user_path(user), { title: I18n.t(:full_level) }
     end
     column :email
     column I18n.t(:workgroups) do |user|

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -59,30 +59,31 @@ ActiveAdmin.register User do
 
   index :download_links => false do
     selectable_column
-    id_column
+    column "Id", sortable: :id do |user|
+      if can?(:edit, user)
+        link_to user.id, edit_admin_user_path(user)
+      else
+        user.id
+      end
+    end
     column :username
-    column :name
+    column :name do |user|
+      link_to user.name, admin_user_path(user)
+    end
     column :email
     column I18n.t(:workgroups) do |user|
-         user.get_workgroups.join(", ")
+      user.get_workgroups.join(", ")
     end
     column I18n.t(:roles) do |user|
-         user.get_roles.join(", ")
+      user.get_roles.join(", ")
     end
-    column :created_at
-    #column (I18n.t :filter_sources) do |user|
-    #  user.sources_size_per_month(Time.now - 1.month, Time.now)
-    #end
-
+    column :created_at, sortable: :created_at
     column :active do |user|
       user.active?
     end
-
     column :disabled do |user|
       user.disabled?
     end
-
-    actions
   end
   
   sidebar :actions, :only => :index do


### PR DESCRIPTION
Muscat inherits default ActiveAdmin actions (View, Edit, Delete) at the right of its lists.  This patch removes those columns and places its links in other places, as proposed in #1405:

* Delete column is removed, as probably it is safer to delete from the full record rather than from the list.
* View column is linked to the Name column, as it is the "main" one, the one that clearly identifiers the record.
* Edit column is linked to the Id colum, but only if the current user has permission to edit it; otherwise, it just shows its value.  Of course, records can also be edited from the full record.

As a small improvement, date of creation column has been made sortable.