### PR TITLE
Adjust script to produce export files with deprecated ids

### DIFF
--- a/housekeeping/export/xml-export.rb
+++ b/housekeeping/export/xml-export.rb
@@ -4,18 +4,31 @@ puts "################################## Export to MarcXML #####################
 puts "##########################################################################################"
 puts ""
 
-# export model with default
-model_name = ARGV[0] ? ARGV[0] : "Source"
-model = model_name.classify.constantize
-# export file with default
-filename = ARGV[1] ? ARGV[1] : "./export.xml"
+require 'optparse'
+
+# Default options
+@options = {
+    :model_name => 'Source',
+    :filename => "./export.xml",
+    :legacy => false
+}
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: example.rb [options]"
+  opts.on('-m', '--model NAME', 'Model name') { |v| @options[:model_name] = v }
+  opts.on('-f', '--file FILE', 'Filename') { |v| @options[:filename] = v }
+  opts.on("-l", "--legacy", "Enable legacy mode") { @options[:legacy] = true }
+end.parse!
+
+# Retrieve the class
+model = @options[:model_name].classify.constantize
 # For sources limit to published records
-published_only = (model_name == "Source") ? {:wf_stage => 1} : {}
+published_only = (@options[:model_name] == "Source") ? {:wf_stage => 1} : {}
 
 # list of ids
 items = model.where(published_only).order(:id).pluck(:id)
 
-file = File.open(filename, "w")
+file = File.open(@options[:filename], "w")
 file.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<collection xmlns=\"http://www.loc.gov/MARC21/slim\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd\">\n")
 
 bar = ProgressBar.new(items.size)

--- a/housekeeping/export/xml-export.rb
+++ b/housekeeping/export/xml-export.rb
@@ -24,6 +24,8 @@ end.parse!
 model = @options[:model_name].classify.constantize
 # For sources limit to published records
 published_only = (@options[:model_name] == "Source") ? {:wf_stage => 1} : {}
+#  Deprecated ids
+deprecated_ids = (@options[:legacy]) ? "true" : "false"
 
 # list of ids
 items = model.where(published_only).order(:id).pluck(:id)
@@ -36,7 +38,7 @@ bar = ProgressBar.new(items.size)
 items.each do |s|
   record = model.find(s)
   # Add deprecated_ids: "false" if necessary
-  file.write(record.marc.to_xml_record({ created_at: record.created_at, updated_at: record.updated_at, holdings: true }).root.to_s)
+  file.write(record.marc.to_xml_record({ created_at: record.created_at, updated_at: record.updated_at, holdings: true, deprecated_ids: deprecated_ids }).root.to_s)
 
   bar.increment!
   record = nil


### PR DESCRIPTION
* Change to options (`-m` for the model and `-f` for the filename)
* Add `-l` for legacy deprecated ids