### PR TITLE
Additional option for exporting all (including unpublished) records

### DIFF
--- a/config/marc/tag_config_work_node.yml
+++ b/config/marc/tag_config_work_node.yml
@@ -48,7 +48,7 @@
   "024":
     :master: a
     :indicator: "7#"
-    :occurrences: "*"
+    :occurrences: "?"
     :fields:
     - - a
       - :occurrences: "1"

--- a/housekeeping/export/xml-export.rb
+++ b/housekeeping/export/xml-export.rb
@@ -8,22 +8,24 @@ require 'optparse'
 
 # Default options
 @options = {
-    :model_name => 'Source',
-    :filename => "./export.xml",
-    :legacy => false
+  :filename => "./export.xml",
+  :model_name => 'Source',
+  :all => false,
+  :legacy => false
 }
 
 OptionParser.new do |opts|
   opts.banner = "Usage: example.rb [options]"
-  opts.on('-m', '--model NAME', 'Model name') { |v| @options[:model_name] = v }
   opts.on('-f', '--file FILE', 'Filename') { |v| @options[:filename] = v }
+  opts.on('-m', '--model NAME', 'Model name') { |v| @options[:model_name] = v }
+  opts.on("-a", "--all", "All records (including unpublished)") { @options[:all] = true }
   opts.on("-l", "--legacy", "Enable legacy mode") { @options[:legacy] = true }
 end.parse!
 
 # Retrieve the class
 model = @options[:model_name].classify.constantize
 # For sources limit to published records
-published_only = (@options[:model_name] == "Source") ? {:wf_stage => 1} : {}
+published_only = (@options[:all]) ? {} : {:wf_stage => 1}
 #  Deprecated ids
 deprecated_ids = (@options[:legacy]) ? "true" : "false"
 

--- a/housekeeping/export/xml-export.rb
+++ b/housekeeping/export/xml-export.rb
@@ -34,6 +34,7 @@ items = model.where(published_only).order(:id).pluck(:id)
 
 file = File.open(@options[:filename], "w")
 file.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<collection xmlns=\"http://www.loc.gov/MARC21/slim\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd\">\n")
+file.write("<!-- Exported from Muscat version #{Git::VERSION} on #{DateTime.now} -->\n")
 
 bar = ProgressBar.new(items.size)
 

--- a/lib/marc.rb
+++ b/lib/marc.rb
@@ -91,6 +91,7 @@ class Marc
     by_tags("005").each {|t| t.destroy_yourself}
     by_tags("008").each {|t| t.destroy_yourself}
   end
+
   # TODO arguments should use parameters or keywords
   def to_external(created_at = nil, updated_at = nil, versions = nil, holdings = false, deprecated_ids = true)
     # cataloguing agency
@@ -121,6 +122,13 @@ class Marc
     by_tags("599").each {|t| t.destroy_yourself}
   end
   
+  def add_auth_leader()
+    # This leader represents a new (05-n), Authority (06-z) record, using UTF-8 encoding (08-#)  
+    leader = "00000nz###2200037nu#4500"
+    new_leader = MarcNode.new(@model, "000", leader, "")
+    @root.children.insert(get_insert_position("000"), new_leader)
+  end
+
   # Parse a MARC 21 line
   def parse_marc21(tag, data)
     # Warning! we are skipping the tag that are not included in MarcConfig

--- a/lib/marc_institution.rb
+++ b/lib/marc_institution.rb
@@ -65,9 +65,12 @@ class MarcInstitution < Marc
       end
     end
   end
+
   def to_external(created_at = nil, updated_at = nil, versions = nil, holdings = false, deprecated_ids = true)
     super(created_at, updated_at, versions)
     parent_object = Institution.find(get_id)
+
+    add_auth_leader()
     
     by_tags("667").each {|t| t.destroy_yourself}
 

--- a/lib/marc_person.rb
+++ b/lib/marc_person.rb
@@ -71,7 +71,9 @@ class MarcPerson < Marc
   
   def to_external(created_at = nil, updated_at = nil, versions = nil, holdings = false, deprecated_ids = true)
     super(created_at, updated_at, versions)
-    
+
+    add_auth_leader()
+
     by_tags("667").each {|t| t.destroy_yourself}
   end
  

--- a/lib/marc_publication.rb
+++ b/lib/marc_publication.rb
@@ -69,6 +69,9 @@ class MarcPublication < Marc
     first_occurance("001").content = "__TEMP__"
   end
 
-
+  def to_external(created_at = nil, updated_at = nil, versions = nil, holdings = false, deprecated_ids = true)
+    super(created_at, updated_at, versions)
+    add_auth_leader()
+  end
 
 end

--- a/lib/marc_source.rb
+++ b/lib/marc_source.rb
@@ -366,7 +366,7 @@ class MarcSource < Marc
     # Step 1, make leader
     # manuscript and print, if it is part of a collection (......[cd]d...............) or not (......[cd]m...............)
 
-    base_leader = "00000nXX#a2200000#u#4500"
+    base_leader = "00000nXX##2200000#u#4500"
 
     if (@record_type == RECORD_TYPES[:collection])
       leader = base_leader.gsub("XX", "dc")

--- a/lib/marc_source.rb
+++ b/lib/marc_source.rb
@@ -525,15 +525,18 @@ class MarcSource < Marc
     # Add a 930 $0 referering to the work node 024
     each_by_tag("930") do |t|
       if t.foreign_object and t.foreign_object.marc
-        # Look for each 024 in the work node
+        d0 = t.fetch_first_by_tag("0")
+        d0.destroy_yourself if d0
+        # Look for each 024 in the work node that we can resolve
         t.foreign_object.marc.each_by_tag("024") do |ft|
           s2 = ft.fetch_first_by_tag("2")
           a = ft.fetch_first_by_tag("a")
           next if (!s2 || !a || !s2.content || !a.content)
           t.add_at(MarcNode.new(@model, "0", "(#{s2.content})#{a.content}", nil), 0) rescue nil
+          # Only add one since 024 should actually be not repeatable
+          break
         end
       end
-      # Eventually we want to remove the $0 pointing to the work_node ID but left for 9.0
     end
 
     # Adding digital object links to 500 with new records

--- a/lib/marc_work.rb
+++ b/lib/marc_work.rb
@@ -74,6 +74,8 @@ class MarcWork < Marc
 
   # Make sure we do not use the default to_external
   def to_external(created_at = nil, updated_at = nil, versions = nil, holdings = false, deprecated_ids = true)
+    super(created_at, updated_at, versions)
+    add_auth_leader("work")
   end
 
 end


### PR DESCRIPTION
Example:
```
# Sources
bundle exec rails r ./housekeeping/export/xml-export.rb -f ./sources.xml -m Source
# Sources with deprecated ids
bundle exec rails r ./housekeeping/export/xml-export.rb -f ./sources-legacy.xml -m Source -l

# Institutions
bundle exec rails r ./housekeeping/export/xml-export.rb -f ./institutions.xml -m Institution -a
# Institutions with deprecated ids
bundle exec rails r ./housekeeping/export/xml-export.rb -f ./institutions-legacy.xml -m Institution -a -l

# People
bundle exec rails r ./housekeeping/export/xml-export.rb -f ./people.xml -m Person -a
# People with deprecated ids
bundle exec rails r ./housekeeping/export/xml-export.rb -f ./people-legacy.xml -m Person -a -l

# Publications
bundle exec rails r ./housekeeping/export/xml-export.rb -f ./publications.xml -m Publication -a
# Publications with deprecated ids
bundle exec rails r ./housekeeping/export/xml-export.rb -f ./publications-legacy.xml -m Publication -a -l
```