### PR TITLE
Display record status tag in full record and edit screen

### DIFF
--- a/app/admin/institution.rb
+++ b/app/admin/institution.rb
@@ -51,7 +51,7 @@ ActiveAdmin.register Institution do
       @show_history = true if params[:show_history]
       @editor_profile = EditorConfiguration.get_default_layout @item
       @editor_validation = EditorValidation.get_default_validation(@item)
-      @page_title = "#{I18n.t(:edit)} #{@editor_profile.name} [#{@item.id}]"
+      @page_title = "#{I18n.t(:edit)} #{@editor_profile.name} [#{@item.id}] #{get_wf_stage_tag(@item.wf_stage)}".html_safe
 
       if cannot?(:edit, @item)
         redirect_to admin_institution_path(@item), :flash => { :error => I18n.t(:"active_admin.access_denied.message") }
@@ -169,7 +169,7 @@ ActiveAdmin.register Institution do
   ## Show ##
   ##########
 
-  show :title => proc{ active_admin_auth_show_title( @item.full_name, @item.siglum, @item.id) } do
+  show :title => proc{ active_admin_auth_show_title( @item.full_name, @item.siglum, @item.id, @item.wf_stage).html_safe } do
     # @item retrived by from the controller is not available there. We need to get it from the @arbre_context
     active_admin_navigation_bar( self )
 

--- a/app/admin/liturgical_feast.rb
+++ b/app/admin/liturgical_feast.rb
@@ -133,7 +133,7 @@ ActiveAdmin.register LiturgicalFeast do
   ## Show ##
   ##########
   
-  show do
+  show :title => proc{ active_admin_auth_show_title(@liturgical_feast.name, nil, @liturgical_feast.id, @liturgical_feast.wf_stage).html_safe } do
     active_admin_navigation_bar( self )
     render('jobs/jobs_monitor')
     attributes_table do
@@ -174,7 +174,7 @@ ActiveAdmin.register LiturgicalFeast do
   ## Edit ##
   ##########
   
-  form do |f|
+  form :title => proc{ active_admin_auth_show_title(I18n.t(:edit), @liturgical_feast.name, @liturgical_feast.id, @liturgical_feast.wf_stage).html_safe } do |f|
     f.inputs do
       f.input :name, :label => (I18n.t :filter_name), input_html: {data: {trigger: triggers_from_hash({save: ["referring_sources", "referring_works"]}) }}
       f.input :alternate_terms, :label => (I18n.t :filter_alternate_terms)

--- a/app/admin/person.rb
+++ b/app/admin/person.rb
@@ -64,7 +64,7 @@ ActiveAdmin.register Person do
       @show_history = true if params[:show_history]
       @editor_profile = EditorConfiguration.get_default_layout @item
       @editor_validation = EditorValidation.get_default_validation(@item)
-      @page_title = "#{I18n.t(:edit)} #{@editor_profile.name} [#{@item.id}]"
+      @page_title = "#{I18n.t(:edit)} #{@editor_profile.name} [#{@item.id}] #{get_wf_stage_tag(@item.wf_stage)}".html_safe
 
       if cannot?(:edit, @item)
         redirect_to admin_person_path(@item), :flash => { :error => I18n.t(:"active_admin.access_denied.message") }
@@ -227,7 +227,7 @@ ActiveAdmin.register Person do
   ## Show ##
   ##########
 
-  show :title => proc{ active_admin_auth_show_title( @item.full_name, @item.life_dates, @item.id) } do
+  show :title => proc{ active_admin_auth_show_title( @item.full_name, @item.life_dates, @item.id, @item.wf_stage).html_safe } do
     # @item retrived by from the controller is not available there. We need to get it from the @arbre_context
     active_admin_navigation_bar( self )
 

--- a/app/admin/place.rb
+++ b/app/admin/place.rb
@@ -148,7 +148,7 @@ ActiveAdmin.register Place do
   ## Show ##
   ##########
 
-  show do
+  show :title => proc{ active_admin_auth_show_title(@place.name, nil, @place.id, @place.wf_stage).html_safe } do
     active_admin_navigation_bar( self )
     render('jobs/jobs_monitor')
     attributes_table do
@@ -255,7 +255,7 @@ ActiveAdmin.register Place do
   ## Edit ##
   ##########
 
-  form do |f|
+  form :title => proc{ active_admin_auth_show_title(I18n.t(:edit), @place.name, @place.id, @place.wf_stage).html_safe } do |f|
     f.inputs do
       f.input :name, :label => (I18n.t :filter_name), input_html: {data: {trigger: triggers_from_hash({save: ["referring_sources", "referring_holdings", "referring_people", "referring_institutions", "referring_publications", "referring_works"]}) }}
       f.input :alternate_terms, :label => (I18n.t :filter_alternate_terms)

--- a/app/admin/publication.rb
+++ b/app/admin/publication.rb
@@ -94,7 +94,7 @@ ActiveAdmin.register Publication do
       @show_history = true if params[:show_history]
       @editor_profile = EditorConfiguration.get_default_layout @item
       @editor_validation = EditorValidation.get_default_validation(@item)
-      @page_title = "#{I18n.t(:edit)} #{@editor_profile.name} [#{@item.id}]"
+      @page_title = "#{I18n.t(:edit)} #{@editor_profile.name} [#{@item.id}] #{get_wf_stage_tag(@item.wf_stage)}".html_safe
 
       if cannot?(:edit, @item)
         redirect_to admin_publication_path(@item), :flash => { :error => I18n.t(:"active_admin.access_denied.message") }
@@ -215,7 +215,7 @@ ActiveAdmin.register Publication do
   ## Show ##
   ##########
   
-  show :title => proc{ active_admin_publication_show_title( @item.author, @item.title.truncate(60), @item.id) } do
+  show :title => proc{ active_admin_publication_show_title( @item.author, @item.title.truncate(60), @item.id, @item.wf_stage).html_safe } do
     # @item retrived by from the controller is not available there. We need to get it from the @arbre_context
     active_admin_navigation_bar( self )
     render('jobs/jobs_monitor')

--- a/app/admin/source.rb
+++ b/app/admin/source.rb
@@ -94,7 +94,7 @@ ActiveAdmin.register Source do
       @editor_validation = EditorValidation.get_default_validation(@item)
       record_type = @item.get_record_type
       record_type = record_type ? " - #{I18n.t('record_types.' + record_type.to_s)}" : ""
-      @page_title = "#{I18n.t(:edit)}#{record_type} [#{@item.id}]"
+      @page_title = "#{I18n.t(:edit)}#{record_type} [#{@item.id}] #{get_wf_stage_tag(@item.wf_stage)}".html_safe
       
       template = EditorConfiguration.get_source_default_file(@item.get_record_type) + ".marc"
 
@@ -371,7 +371,7 @@ ActiveAdmin.register Source do
   ## Show ##
   ##########
   
-  show :title => proc{ active_admin_source_show_title( @item.composer, @item.std_title, @item.id, @item.get_record_type) } do
+  show :title => proc{ active_admin_source_show_title( @item.composer, @item.std_title, @item.id, @item.get_record_type, @item.wf_stage).html_safe } do
     # @item retrived by from the controller is not available there. We need to get it from the @arbre_context
     active_admin_navigation_bar( self )
     @item = @arbre_context.assigns[:item]

--- a/app/admin/standard_term.rb
+++ b/app/admin/standard_term.rb
@@ -147,7 +147,7 @@ ActiveAdmin.register StandardTerm do
   ## Show ##
   ##########
   
-  show :title => :term do
+  show :title => proc{ active_admin_auth_show_title(@standard_term.name, nil, @standard_term.id, @standard_term.wf_stage).html_safe } do
     active_admin_navigation_bar( self ) 
     render('jobs/jobs_monitor')
     attributes_table do
@@ -203,7 +203,7 @@ ActiveAdmin.register StandardTerm do
   ## Edit ##
   ##########
   
-  form do |f|
+  form :title => proc{ active_admin_auth_show_title(I18n.t(:edit), @standard_term.name, @standard_term.id, @standard_term.wf_stage).html_safe } do |f|
     f.inputs do
       f.input :term, :label => (I18n.t :filter_term), input_html: {data: {trigger: triggers_from_hash({save: ["referring_sources", "referring_publications", "referring_works"]}) }}
       f.input :alternate_terms, :label => (I18n.t :filter_alternate_terms), :input_html => { :rows => 8 }

--- a/app/admin/standard_title.rb
+++ b/app/admin/standard_title.rb
@@ -165,7 +165,7 @@ ActiveAdmin.register StandardTitle do
   ## Show ##
   ##########
   
-  show do
+  show :title => proc{ active_admin_auth_show_title(@standard_title.name, nil, @standard_title.id, @standard_title.wf_stage).html_safe } do
     active_admin_navigation_bar( self )
     render('jobs/jobs_monitor')
     attributes_table do
@@ -208,7 +208,7 @@ ActiveAdmin.register StandardTitle do
   ## Edit ##
   ##########
   
-  form do |f|
+  form :title => proc{ active_admin_auth_show_title(I18n.t(:edit), @standard_title.name, @standard_title.id, @standard_title.wf_stage).html_safe } do |f|
     f.inputs do
       ## Enable the trigger, only for editors
       if current_user.has_any_role?(:editor, :admin)

--- a/app/admin/work.rb
+++ b/app/admin/work.rb
@@ -250,7 +250,7 @@ ActiveAdmin.register Work do
   ## Show ##
   ##########
   
-  show :title => proc{ active_admin_auth_show_title( @item.title, nil, @item.id) } do
+  show :title => proc{ active_admin_auth_show_title( @item.title, nil, @item.id, @item.wf_stage).html_safe } do
     # @item retrived by from the controller is not available there. We need to get it from the @arbre_context
     active_admin_navigation_bar( self )
     

--- a/app/admin/work_node.rb
+++ b/app/admin/work_node.rb
@@ -58,7 +58,7 @@ ActiveAdmin.register WorkNode do
       @show_history = true if params[:show_history]
       @editor_profile = EditorConfiguration.get_default_layout @item
       @editor_validation = EditorValidation.get_default_validation(@item)
-      @page_title = "#{I18n.t(:edit)} #{@editor_profile.name} [#{@item.id}]"
+      @page_title = "#{I18n.t(:edit)} #{@editor_profile.name} [#{@item.id}] #{get_wf_stage_tag(@item.wf_stage)}".html_safe
 
       @restricted=""
     end
@@ -151,7 +151,7 @@ ActiveAdmin.register WorkNode do
   ## Show ##
   ##########
   
-  show :title => proc{ active_admin_auth_show_title( @item.title, nil, @item.id) } do
+  show :title => proc{ active_admin_auth_show_title( @item.title, nil, @item.id, @item.wf_stage).html_safe } do
     # @item retrived by from the controller is not available there. We need to get it from the @arbre_context
     active_admin_navigation_bar( self )
     

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,8 @@ class ApplicationController < ActionController::Base
   before_action :store_user_location!, if: :storable_location?
   before_action :set_locale, :set_paper_trail_whodunnit, :auth_user, :prepare_exception_notifier, :test_version_warning, :test_muscat_reindexing
 
+  helper_method :get_wf_stage_tag # so it is also accessible from views
+
   # see https://github.com/heartcombo/devise/wiki/How-To:-Redirect-back-to-current-page-after-sign-in,-sign-out,-sign-up,-update
   def storable_location?
     request.get? && is_navigational_format? && !devise_controller? && !request.xhr? 
@@ -131,6 +133,11 @@ class ApplicationController < ActionController::Base
   def save_search_filters  
   end
   
+  def get_wf_stage_tag(wf_stage)
+    stage_label = I18n.t("status_codes.#{wf_stage}", locale: :en)
+    Arbre::Context.new{ status_tag(wf_stage, label: stage_label) }
+  end
+
   private
   
   # Parse the http header to get a locale

--- a/app/helpers/active_admin/views_helper.rb
+++ b/app/helpers/active_admin/views_helper.rb
@@ -150,13 +150,20 @@ module ActiveAdmin::ViewsHelper
   end
   
   # formats the string for the source show title
-  def active_admin_source_show_title( composer, std_title, id, record_type )
+  def active_admin_source_show_title( composer, std_title, id, record_type, wf_stage )
     record_type = record_type ? "#{I18n.t('record_types.' + record_type.to_s)} " : ""
-    return "#{record_type}[#{id}]" if !composer or std_title
-    return "#{record_type}[#{id}]" if composer.empty? and std_title.empty?
-    return "#{std_title} - #{record_type}[#{id}]" if composer.empty? and !std_title.empty?
-    return "#{composer} - #{record_type}[#{id}]" if (std_title.nil? or std_title.empty?)
-    return "#{composer} : #{std_title} - #{record_type}[#{id}]"
+    if !composer || std_title
+      title_display = "#{record_type}[#{id}]"
+    elsif composer.empty? && std_title.empty?
+      title_display = "#{record_type}[#{id}]"
+    elsif composer.empty? && !std_title.empty?
+      title_display = "#{std_title} - #{record_type}[#{id}]"
+    elsif std_title.nil? || std_title.empty?
+      title_display = "#{composer} - #{record_type}[#{id}]"
+    else
+      title_display = "#{composer} : #{std_title} - #{record_type}[#{id}]"
+    end
+    title_display += " #{get_wf_stage_tag(wf_stage)}"
   end
   
   # formats the string for the holding show title
@@ -168,20 +175,32 @@ module ActiveAdmin::ViewsHelper
   end
   
   # formats the string for the source show title
-  def active_admin_auth_show_title( val1, val2, id )
+  def active_admin_auth_show_title( val1, val2, id, wf_stage )
     val1 = "" if !val1
     val2 = "" if !val2
-    return "[#{id}]" if val1.empty? and val2.empty?
-    return "#{val2} - [#{id}]" if val1.empty? and !val2.empty?
-    return "#{val1} - [#{id}]" if (val2.nil? or val2.empty?)
-    return "#{val1} : #{val2} - [#{id}]"
+    if val1.empty? && val2.empty?
+      title_display = "[#{id}]"
+    elsif val1.empty? && !val2.empty?
+      title_display = "#{val2} - [#{id}]"
+    elsif val2.nil? || val2.empty?
+      title_display = "#{val1} - [#{id}]"
+    else
+      title_display = "#{val1} : #{val2} - [#{id}]"
+    end
+    title_display += " #{get_wf_stage_tag(wf_stage)}"
   end
  
-  def active_admin_publication_show_title( author, title, id )
-    return "[#{id}]" if author.empty? and title.empty?
-    return "#{title} [#{id}]" if author.empty? and !title.empty?
-    return "#{author} [#{id}]" if (title.nil? or title.empty?)
-    return "#{author} : #{title} [#{id}]"
+  def active_admin_publication_show_title( author, title, id, wf_stage )
+    if author.empty? && title.empty?
+      title_display = "[#{id}]"
+    elsif author.empty? && !title.empty?
+      title_display = "#{title} [#{id}]"
+    elsif title.nil? || title.empty?
+      title_display = "#{author} [#{id}]"
+    else
+      title_display = "#{author} : #{title} [#{id}]"
+    end
+    title_display += " #{get_wf_stage_tag(wf_stage)}"
   end
   
   def active_admin_digital_object_show_title( description, id )


### PR DESCRIPTION
Record status is only visible in the record lists screen, but not when the records are shown or edited.  Display it at the top of the screen using the same ActiveAdmin status_tag than in the lists.

Closes #1649