### PR TITLE
After modifying non-marc authority files, show modified record

### DIFF
--- a/app/admin/liturgical_feast.rb
+++ b/app/admin/liturgical_feast.rb
@@ -70,7 +70,7 @@ ActiveAdmin.register LiturgicalFeast do
     # redirect update failure for preserving sidebars
     def update
       update! do |success,failure|
-        success.html { redirect_to collection_path }
+        success.html { redirect_to resource_path(params[:id]) }
         failure.html { redirect_back fallback_location: root_path, flash: { :error => "#{I18n.t(:error_saving)}" } }
       end
       # Run the eventual triggers

--- a/app/admin/place.rb
+++ b/app/admin/place.rb
@@ -69,7 +69,7 @@ ActiveAdmin.register Place do
     # redirect update failure for preserving sidebars
     def update
       update! do |success,failure|
-        success.html { redirect_to collection_path }
+        success.html { redirect_to resource_path(params[:id]) }
         failure.html { redirect_back fallback_location: root_path, flash: { :error => "#{I18n.t(:error_saving)}" } }
       end
       # Run the eventual triggers

--- a/app/admin/standard_term.rb
+++ b/app/admin/standard_term.rb
@@ -86,7 +86,7 @@ ActiveAdmin.register StandardTerm do
     # redirect update failure for preserving sidebars
     def update
       update! do |success,failure|
-        success.html { redirect_to collection_path }
+        success.html { redirect_to resource_path(params[:id]) }
         failure.html { redirect_back fallback_location: root_path, flash: { :error => "#{I18n.t(:error_saving)}" } }
       end
 

--- a/app/admin/standard_title.rb
+++ b/app/admin/standard_title.rb
@@ -92,7 +92,7 @@ ActiveAdmin.register StandardTitle do
     # redirect update failure for preserving sidebars
     def update
       update! do |success,failure|
-        success.html { redirect_to collection_path }
+        success.html { redirect_to resource_path(params[:id]) }
         failure.html { redirect_back fallback_location: root_path, flash: { :error => "#{I18n.t(:error_saving)}" } }
       end
 


### PR DESCRIPTION
Currently, after editing those records, Muscat takes you to the record list, without allowing to double-check if the editing was right.

Partially closes #1584