### PR TITLE
Display wf_stage in place authority records

### DIFF
--- a/app/admin/place.rb
+++ b/app/admin/place.rb
@@ -274,6 +274,7 @@ ActiveAdmin.register Place do
       f.input :country, :label => (I18n.t :filter_country), :as => :string # otherwise country-select assumed
       f.input :district, :label => (I18n.t :filter_district)
       f.input :notes, :label => (I18n.t :filter_notes)
+      f.input :wf_stage, :label => (I18n.t :filter_wf_stage)
       f.input :lock_version, :as => :hidden
     end
   end


### PR DESCRIPTION
Of all non-marc authority records, place is the only that doesn't display wf_stage, although the field exists in the database.  Make it visible, so it is homogeneous with the others.

Part of #1584