### PR TITLE
Update SourceLabels.yml

### DIFF
--- a/config/editor_profiles/default/configurations/SourceLabels.yml
+++ b/config/editor_profiles/default/configurations/SourceLabels.yml
@@ -324,7 +324,7 @@
     b:
       label: general.rism_series_number
     c:
-      label: records.reference_record_id
+      label: records.rism_id_number
   label: general.rism_series_a_b_references
 '597':
   fields:


### PR DESCRIPTION
Related to https://github.com/rism-digital/muscat/issues/1721 (in that it has to do with 787 and 596):
Both 596$c and 787$w link to the RISM ID number. I don't think they need two separate labels. I propose making them the same label, as in 787$w `RISM ID number` which uses the key `records.rism_id_number`.