### PR TITLE
harden: detected non-static command inside 'open' in...

### DIFF
--- a/housekeeping/import/convert_to_utf8.rb
+++ b/housekeeping/import/convert_to_utf8.rb
@@ -5,8 +5,8 @@ require 'iconv'
 if ARGV.length == 2
   source_file = ARGV[0]
   if File.exist?(source_file)
-    conv = Iconv.new('utf-8', 'windows-1252').iconv(open(ARGV[0]).read)
-    out = open(ARGV[1], "wb")
+    conv = Iconv.new('utf-8', 'windows-1252').iconv(File.open(ARGV[0]).read)
+    out = File.open(ARGV[1], "wb")
     out.write(conv)
     out.close
   else


### PR DESCRIPTION
## Summary
Harden input handling in `housekeeping/import/convert_to_utf8.rb` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | ruby.lang.security.dangerous-open.dangerous-open |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `ruby.lang.security.dangerous-open.dangerous-open` |
| **File** | `housekeeping/import/convert_to_utf8.rb:8` |
| **Assessment** | Defensive hardening |

**Description**: Detected non-static command inside 'open'. Audit the input to 'open'. If unverified user data can reach this call site, this is a code injection vulnerability. A malicious actor can inject a malicious script to execute arbitrary code.

## Threat Model Context

This is a private Node.js application (not published to npm). Vulnerabilities affect this application's own runtime only.

## Changes
- `housekeeping/import/convert_to_utf8.rb`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
