### PR TITLE
New: Add telemetry to the validation checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Muscat is a framework for cataloging music documents (handwritten and printed mu
 * [Configuration](4-CONFIG.md)
 * [MARC21 Configuration and management](5-MARC_CONFIG.md)
 * [RSPEC](6-RSPEC.md)
+* [Validation observability](doc/9-VALIDATION_OBSERVABILITY.md)
 
 ### Contributors
 

--- a/app/jobs/folder_validation_report_job.rb
+++ b/app/jobs/folder_validation_report_job.rb
@@ -20,12 +20,20 @@ class FolderValidationReportJob < ApplicationJob
         begin_time = Time.now
     
         # Run the checkup function
-        total_errors, total_validations, foreign_tag_errors, unknown_tags = MuscatCheckup.new(folder: folder).validate_parallel
+        result = MuscatCheckup.new(folder: folder).validate_parallel
   
         end_time = Time.now
         message = "Source report started at #{begin_time.to_s}, (#{end_time - begin_time} seconds run time)"
       
-        FolderValidationReport.notify("Source", message, total_errors, total_validations, foreign_tag_errors, unknown_tags, user).deliver_now
+        FolderValidationReport.notify(
+            "Source",
+            message,
+            result.errors,
+            result.validations,
+            result.foreign_tag_errors,
+            result.unknown_tags,
+            user
+        ).deliver_now
       
     end
     

--- a/app/jobs/muscat_checkup_report_job.rb
+++ b/app/jobs/muscat_checkup_report_job.rb
@@ -2,18 +2,22 @@
 class MuscatCheckupReportJob < ApplicationJob
   queue_as :default
   
-  def initialize(mdl = Source)
+  def initialize(mdl = Source, telemetry: false)
     super
     @model = mdl != nil && mdl.is_a?(Class) ? mdl : Source
+    @telemetry = telemetry
   end
 
   def perform()
     begin_time = Time.now
+    observability = ValidationObservability.new if @telemetry
+    stream = observability.start_run!(model: @model, started_at: begin_time) if @telemetry
   
     # For compatibility with older versions, validation.log is always for sources
     file_name = @model.is_a?(Source) ? "validation.log" : "#{@model.to_s.underscore.downcase}_validation.log"
 
-    logger = Logger.new(File.new("#{Rails.root}/log/#{file_name}", 'w'))
+    log_path = "#{Rails.root}/log/#{file_name}"
+    logger = Logger.new(File.new(log_path, 'w'))
     logger.datetime_format = 
     logger.formatter = proc do |severity, datetime, progname, msg|
       #time = datetime.utc.strftime('%Y-%m-%d %H:%M:%SZ')
@@ -21,16 +25,38 @@ class MuscatCheckupReportJob < ApplicationJob
       "#{msg}\n"
     end
 
-    # Run the checkup function
-    total_errors, total_validations, foreign_tag_errors, unknown_tags = MuscatCheckup.new(model: @model, logger: logger, process_exclusions: true).validate_parallel
+    begin
+      # Run the checkup function
+      checkup_options = { model: @model, logger: logger, log_path: log_path, process_exclusions: true }
+      checkup_options[:observability] = stream.metadata if @telemetry
+      results = MuscatCheckup.new(checkup_options).validate_parallel
+      total_errors, total_validations, foreign_tag_errors, unknown_tags, observations = results
 
-    end_time = Time.now
-    duration = (end_time - begin_time).to_i
-    human_readable = format("%02d:%02d:%02d", duration / 3600, (duration % 3600) / 60, duration % 60)
-    message = "#{@model.to_s} report started at #{begin_time.to_s}, (execution time: #{duration} seconds, or in human terms: #{human_readable})"
-    
+      end_time = Time.now
+      duration = (end_time - begin_time).to_i
+      human_readable = format("%02d:%02d:%02d", duration / 3600, (duration % 3600) / 60, duration % 60)
+      message = "#{@model.to_s} report started at #{begin_time.to_s}, (execution time: #{duration} seconds, or in human terms: #{human_readable})"
+
+      if @telemetry
+        observability.complete!(
+          stream: stream,
+          started_at: begin_time,
+          completed_at: end_time,
+          observations: observations
+        )
+      end
+    rescue StandardError => e
+      if @telemetry
+        begin
+          stream.run_failed(e)
+        rescue StandardError => event_error
+          Rails.logger.error("validation_observability_failure_event_failed model=#{@model} error=#{event_error.class}: #{event_error.message}")
+        end
+      end
+      raise
+    end
+
     HealthReport.notify(@model.to_s, message, total_errors, total_validations, foreign_tag_errors, unknown_tags).deliver_now
-    
   end
   
 end

--- a/app/jobs/muscat_checkup_report_job.rb
+++ b/app/jobs/muscat_checkup_report_job.rb
@@ -29,8 +29,7 @@ class MuscatCheckupReportJob < ApplicationJob
       # Run the checkup function
       checkup_options = { model: @model, logger: logger, log_path: log_path, process_exclusions: true }
       checkup_options[:observability] = stream.metadata if @telemetry
-      results = MuscatCheckup.new(checkup_options).validate_parallel
-      total_errors, total_validations, foreign_tag_errors, unknown_tags, observations = results
+      result = MuscatCheckup.new(checkup_options).validate_parallel
 
       end_time = Time.now
       duration = (end_time - begin_time).to_i
@@ -42,7 +41,7 @@ class MuscatCheckupReportJob < ApplicationJob
           stream: stream,
           started_at: begin_time,
           completed_at: end_time,
-          observations: observations
+          observations: result.observations
         )
       end
     rescue StandardError => e
@@ -56,7 +55,14 @@ class MuscatCheckupReportJob < ApplicationJob
       raise
     end
 
-    HealthReport.notify(@model.to_s, message, total_errors, total_validations, foreign_tag_errors, unknown_tags).deliver_now
+    HealthReport.notify(
+      @model.to_s,
+      message,
+      result.errors,
+      result.validations,
+      result.foreign_tag_errors,
+      result.unknown_tags
+    ).deliver_now
   end
   
 end

--- a/app/jobs/muscat_maintenance_job.rb
+++ b/app/jobs/muscat_maintenance_job.rb
@@ -16,12 +16,12 @@ class MuscatMaintenanceJob < ApplicationJob
 
         # Run the checkup function
         checkup = MuscatCheckup.new({model: @base_model, jobs: 10, skip_validation: true, skip_dates: true, skip_unknown_tags: true, skip_dead_774: true, skip_588_validation: true, skip_validate_work_status: true})
-        total_errors, total_validations, foreign_tag_errors, unknown_tags = checkup.validate_parallel
+        result = checkup.validate_parallel
 
         # Force a reconnect
         ActiveRecord::Base.connection.reconnect!
 
-        foreign_tag_errors.each do |error|
+        result.foreign_tag_errors.each do |error|
             # Model is the linked to item
             # i.e. a StdTitle in a source,
             # and Model = standard_title

--- a/bin/muscat_execute_job
+++ b/bin/muscat_execute_job
@@ -16,7 +16,7 @@ LOGFILE=$MUSCAT_ROOT/log/muscat_execute_job.log
 #RVM_CMD="/PATH_TO/.rvm/bin/rvm 3.2.2@rails7 do"
 
 if [ $# -eq 0 ]; then
-    echo "muscat_execute_job <job> <env> [param] [--telemetry]"
+    echo "muscat_execute_job <job> [env] [param] [--telemetry]"
     exit 1
 fi
 
@@ -26,19 +26,16 @@ if [ -z "$1" ]; then
 fi
 
 JOB_NAME=$1
+shift
 
-if [ -z "$2" ]; then
-    export RAILS_ENV=production
-else
-    if [ $2 == "production" ] || [ $2 == "development" ] || [ $2 == "test" ]; then
-        export RAILS_ENV=$2
-    else
-        echo "Invalid RAILS_ENV $2"
-        exit 1
-    fi
-fi
+export RAILS_ENV=production
+case "$1" in
+    production|development|test)
+        export RAILS_ENV=$1
+        shift
+        ;;
+esac
 
-shift 2
 PARAMETER=
 TELEMETRY=false
 

--- a/bin/muscat_execute_job
+++ b/bin/muscat_execute_job
@@ -16,11 +16,13 @@ LOGFILE=$MUSCAT_ROOT/log/muscat_execute_job.log
 #RVM_CMD="/PATH_TO/.rvm/bin/rvm 3.2.2@rails7 do"
 
 if [ $# -eq 0 ]; then
-    echo "muscat_execute_job <job> <env> <param>"
+    echo "muscat_execute_job <job> <env> [param] [--telemetry]"
+    exit 1
 fi
 
 if [ -z "$1" ]; then
     echo "No job supplied"
+    exit 1
 fi
 
 JOB_NAME=$1
@@ -36,6 +38,35 @@ else
     fi
 fi
 
+shift 2
+PARAMETER=
+TELEMETRY=false
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --telemetry)
+            TELEMETRY=true
+            ;;
+        --*)
+            echo "Unknown flag: $1"
+            exit 1
+            ;;
+        *)
+            if [ -n "$PARAMETER" ]; then
+                echo "Only one job parameter is supported"
+                exit 1
+            fi
+            PARAMETER=$1
+            ;;
+    esac
+    shift
+done
+
+if [ "$TELEMETRY" = true ] && [ "$JOB_NAME" != "MuscatCheckupReportJob" ]; then
+    echo "--telemetry is only supported by MuscatCheckupReportJob"
+    exit 1
+fi
+
 cd $MUSCAT_ROOT
 
 DATE=`date`
@@ -44,10 +75,15 @@ start=$SECONDS
 echo "Running $JOB_NAME in $RAILS_ENV mode at $DATE" >> $LOGFILE 2>&1
 echo "Start $JOB_NAME in $RAILS_ENV mode at $DATE" >> $MUSCAT_ROOT/log/"$JOB_NAME.log"
 
-if [ -z "$3" ]; then
+if [ "$TELEMETRY" = true ]; then
+    if [ -z "$PARAMETER" ]; then
+        echo "$JOB_NAME.new(telemetry: true).perform" | $RVM_CMD bundle exec rails c >> $MUSCAT_ROOT/log/"$JOB_NAME.log"
+    else
+        echo "$JOB_NAME.new($PARAMETER, telemetry: true).perform" | $RVM_CMD bundle exec rails c >> $MUSCAT_ROOT/log/"$JOB_NAME.log"
+    fi
+elif [ -z "$PARAMETER" ]; then
     echo "$JOB_NAME.new.perform" | $RVM_CMD bundle exec rails c >> $MUSCAT_ROOT/log/"$JOB_NAME.log"
 else
-    PARAMETER=$3
     echo "$JOB_NAME.new($PARAMETER).perform" | $RVM_CMD bundle exec rails c >> $MUSCAT_ROOT/log/"$JOB_NAME.log"
 fi
 

--- a/config/muscat-validation.alloy.example
+++ b/config/muscat-validation.alloy.example
@@ -1,0 +1,26 @@
+// Parameterized Grafana Alloy example for scheduled Muscat validation output.
+// Replace the paths and connect the receivers to your existing remote_write and
+// Loki write components. Keep your existing host-label relabeling in place.
+
+prometheus.exporter.unix "local" {
+  // Enable/configure the textfile collector in the existing Unix exporter.
+  // Exact collector options can vary by Alloy version; set its directory to:
+  // /var/lib/node_exporter/textfile_collector
+}
+
+// Add the Unix exporter target to the existing prometheus.scrape component that
+// remote-writes to monitor.rism.digital. Muscat atomically writes:
+// /var/lib/node_exporter/textfile_collector/muscat_validation_source.prom
+// (one atomically written .prom file per checked model)
+
+loki.source.file "muscat_validation" {
+  targets = [{
+    __path__ = "/var/log/muscat/validation_observability.jsonl",
+    job      = "muscat_validation",
+  }]
+  forward_to = [loki.write.REPLACE_WITH_EXISTING.receiver]
+}
+
+// Configure Muscat with matching writable paths:
+// MUSCAT_VALIDATION_PROMETHEUS_TEXTFILE=/var/lib/node_exporter/textfile_collector/muscat_validation.prom
+// MUSCAT_VALIDATION_LOKI_LOG=/var/log/muscat/validation_observability.jsonl

--- a/config/muscat.logrotate.sample
+++ b/config/muscat.logrotate.sample
@@ -11,3 +11,12 @@
    endscript
 }
 
+/PATH_TO/muscat/log/validation_observability.jsonl {
+    size=100M
+    missingok
+    rotate 10
+    compress
+    delaycompress
+    notifempty
+    copytruncate
+}

--- a/config/muscat_crontab
+++ b/config/muscat_crontab
@@ -39,6 +39,9 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 00  04  *  *  sun muscat PATH_TO/muscat/bin/muscat_execute_job MuscatMaintenanceJob production
 
 # These validate records and send an email
+# Add --telemetry to an individual command only after configuring Alloy, for example:
+# 00 07 * * sun muscat PATH_TO/muscat/bin/muscat_execute_job MuscatCheckupReportJob production --telemetry
+# 00 08 * * sun muscat PATH_TO/muscat/bin/muscat_execute_job MuscatCheckupReportJob production Holding --telemetry
 00  07  *  *  sun muscat PATH_TO/muscat/bin/muscat_execute_job MuscatCheckupReportJob production
 00  08  *  *  sun muscat PATH_TO/muscat/bin/muscat_execute_job MuscatCheckupReportJob production Holding
 10  08  *  *  sun muscat PATH_TO/muscat/bin/muscat_execute_job MuscatCheckupReportJob production Work

--- a/doc/9-VALIDATION_OBSERVABILITY.md
+++ b/doc/9-VALIDATION_OBSERVABILITY.md
@@ -1,0 +1,81 @@
+# Validation observability
+
+Telemetry is disabled by default. Existing scheduled checkups continue to
+produce only their validation logs and HTML/email reports. Enable streaming
+Loki events and the final Prometheus snapshot explicitly with:
+
+```text
+bin/muscat_execute_job MuscatCheckupReportJob production --telemetry
+bin/muscat_execute_job MuscatCheckupReportJob production Holding --telemetry
+```
+
+When enabled, the scheduled job streams record-level Loki events while it
+validates a model, then writes the Prometheus snapshot after completion. Folder
+and interactive editor validation are not included.
+
+## Configuration
+
+When using `--telemetry`, set both paths in the environment of the cron/job
+process:
+
+```text
+MUSCAT_VALIDATION_PROMETHEUS_TEXTFILE=/var/lib/node_exporter/textfile_collector/muscat_validation.prom
+MUSCAT_VALIDATION_LOKI_LOG=/var/log/muscat/validation_observability.jsonl
+```
+
+If unset, the paths default to `log/validation_metrics.prom` and
+`log/validation_observability.jsonl` below the Rails root. The destination
+directories must already exist and be writable by the Muscat job user. A write
+failure raises from the scheduled job so Delayed Job retries and reports it as
+a failure.
+
+The configured Prometheus path is a base name. Muscat appends the checked model
+name before `.prom`, for example `muscat_validation_source.prom` and
+`muscat_validation_work.prom`. Each file is written to a temporary file in its
+final directory and renamed into place, so one model's weekly run cannot remove
+another model's latest snapshot. Configure Alloy's local Unix exporter textfile
+collector to read that directory, then retain the normal Alloy scrape and
+remote-write path. `config/muscat-validation.alloy.example` is a parameterized
+collector template; merge it into the site's existing Alloy configuration.
+
+Configure Alloy `loki.source.file` to tail the JSONL path. The example uses a
+static `job="muscat_validation"` label; host labels should continue to be
+added by the site's normal Alloy pipeline.
+
+## Prometheus metrics
+
+Every metric has a `model` label (`Source`, `Holding`, `Work`, or `Person` for
+the default cron schedule):
+
+| Metric | Meaning |
+| --- | --- |
+| `muscat_validation_last_run_completed_timestamp_seconds` | Completion time of the latest exported run. |
+| `muscat_validation_last_run_successful_timestamp_seconds` | Completion time of the latest successfully exported run. |
+| `muscat_validation_last_run_duration_seconds` | Elapsed validation time. |
+| `muscat_validation_last_run_records_scanned` | Records checked. |
+| `muscat_validation_last_run_records_with_findings` | Records with at least one finding. |
+| `muscat_validation_last_run_findings` | Findings, additionally labelled with `record_type` and stable `category`. |
+
+`category` is the validator's existing log/error type, for example
+`validation_error`, `link_error`, `unknown_tag_error`, `date_error`,
+`holding_error`, or a `record_exception_*` processing error. Metrics never use
+record IDs, MARC tags/subtags, or messages as labels, avoiding high cardinality.
+
+## Loki JSON events
+
+Each line is JSON with an ISO-8601 `timestamp`, UUID `run_id`, `workflow`, and
+`model`. A run produces `validation_run_started`, then one
+`validation_message` event as each record produces validation or processing
+findings, and
+finally `validation_run_completed` (or `validation_run_failed`). The record event contains `record_id`,
+`record_type`, and a `findings` array. Each finding retains `category`, `tag`,
+`subtag`, and raw `message` for diagnosis.
+
+Record IDs and messages are fields rather than Loki stream labels. Query them
+after JSON parsing, for example by `run_id`, `record_id`, `category`, or MARC
+tag. Rotate the JSONL file with the additional stanza in
+`config/muscat.logrotate.sample`; `copytruncate` keeps an open tailing reader
+on the same file. Parallel workers take a short exclusive lock for each JSON
+line and flush it immediately, so Alloy can tail failures during a long run.
+The stream does not `fsync` each event; an abrupt host crash can lose entries
+that have not reached disk yet.

--- a/lib/marc_validator.rb
+++ b/lib/marc_validator.rb
@@ -7,7 +7,7 @@ using AggressivelyStrip
 
   DEBUG = false
 
-  def initialize(object, user = nil, warnings = false, logger = nil, exclusions = nil)
+  def initialize(object, user = nil, warnings = false, logger = nil, exclusions = nil, collect_findings: false)
     @validation = EditorValidation.get_default_validation(object)
     @rules = @validation.rules
     @user = user
@@ -16,6 +16,7 @@ using AggressivelyStrip
     @editor_profile = EditorConfiguration.get_default_layout(object)
     #ap @rules
     @errors = {}
+    @findings = [] if collect_findings
     @object = object
     
     @exclusions = exclusions
@@ -583,6 +584,12 @@ using AggressivelyStrip
     @errors
   end
 
+  # Structured findings are kept alongside the historical error hash so that
+  # reporting callers do not need to parse human-readable validation messages.
+  def get_findings
+    @findings || []
+  end
+
   def current_user
     @user
   end
@@ -756,6 +763,14 @@ using AggressivelyStrip
     @errors[tag][subtag] << message
     
     log_tag = "validation_error" if !log_tag
+    if @findings
+      @findings << {
+        tag: tag,
+        subtag: subtag,
+        message: message.to_s,
+        category: log_tag
+      }
+    end
     @logger.error("#{log_tag} #{@object.id} #{print_record_type(@object)} #{tag} #{subtag} #{message}") if @logger
   end
   

--- a/lib/muscat_checkup.rb
+++ b/lib/muscat_checkup.rb
@@ -23,32 +23,13 @@ class RecordCheckupResult
   end
 end
 
-class TelemetryNullWorker
-  def initialize(*)
+class TelemetryWorker
+  def initialize(observability)
     @observations = {
       records_scanned: 0,
       records_with_findings: 0,
       findings: Hash.new(0)
     }
-  end
-
-  def collect_findings?
-    false
-  end
-
-  def technical_findings(output:, exception:, phase:)
-    []
-  end
-
-  def record(record, findings)
-  end
-
-  attr_reader :observations
-end
-
-class TelemetryWorker < TelemetryNullWorker
-  def initialize(observability)
-    super()
     @event_stream = ValidationObservability::EventStream.new(**observability)
   end
 
@@ -70,6 +51,8 @@ class TelemetryWorker < TelemetryNullWorker
 
     findings
   end
+
+  attr_reader :observations
 
   def record(record, findings)
     @observations[:records_scanned] += 1
@@ -109,6 +92,11 @@ class MuscatCheckup
 
   # It was 10, but now we should have exclusions
   UNKNOWN_TAG_LIMIT = 100
+  EMPTY_OBSERVATIONS = {
+    records_scanned: 0,
+    records_with_findings: 0,
+    findings: {}.freeze
+  }.freeze
 
   def initialize(options = {})
     @model = options[:model].is_a?(Class) ? options[:model] : Source
@@ -119,7 +107,7 @@ class MuscatCheckup
 
     @debug_logger = options[:logger]
     @observability = options[:observability]
-    @telemetry_worker_class = @observability.present? ? TelemetryWorker : TelemetryNullWorker
+    @telemetry_enabled = @observability.present?
 
     @skip_validation            = options[:skip_validation] == true
     @skip_dates                 = options[:skip_dates] == true
@@ -181,17 +169,16 @@ class MuscatCheckup
   
   private
 
-  def load_and_validate_item(s, telemetry)
+  def load_and_validate_item(s)
     errors = {}
     validations = {}
-    findings = []
 
     phase = :load
 
     result, output, exception = capture_stdout_and_stderr do
       #s.marc.load_source(true)
       phase = :validate
-      validate_record(s, telemetry)
+      validate_record(s)
     end
 
     unless output.strip.empty?
@@ -203,6 +190,34 @@ class MuscatCheckup
       append_exception(errors, s.id, exception)
       @debug_logger.error("[#{phase}] #{exception.backtrace.first(2).join("\n")}") if @debug_logger
       puts "[#{phase}] #{exception.backtrace.first(2).join("\n")}" # Also print the message on the stdout sink 
+    elsif result.present?
+      validations[s.id] = result
+    end
+
+    [errors, validations]
+  end
+
+  def load_and_validate_item_with_telemetry(s, telemetry)
+    errors = {}
+    validations = {}
+    findings = []
+
+    phase = :load
+
+    result, output, exception = capture_stdout_and_stderr do
+      phase = :validate
+      validate_record_with_telemetry(s, telemetry)
+    end
+
+    unless output.strip.empty?
+      errors[s.id] = output
+      log_output_lines(output, s, exception ? "record_exception_#{phase}" : "record_error")
+    end
+
+    if exception
+      append_exception(errors, s.id, exception)
+      @debug_logger.error("[#{phase}] #{exception.backtrace.first(2).join("\n")}") if @debug_logger
+      puts "[#{phase}] #{exception.backtrace.first(2).join("\n")}"
     elsif result.present?
       validations[s.id] = result.validations if result.validations.present?
       findings.concat(result.findings)
@@ -216,11 +231,7 @@ class MuscatCheckup
       )
     )
 
-    RecordCheckupResult.new(
-      errors: errors,
-      validations: validations,
-      findings: findings
-    )
+    RecordCheckupResult.new(errors: errors, validations: validations, findings: findings)
   end
 
   def capture_stdout_and_stderr
@@ -266,6 +277,37 @@ class MuscatCheckup
   end
 
   def validate_items
+    return validate_items_with_telemetry if telemetry_enabled?
+    validate_items_without_telemetry
+  end
+
+  def validate_items_without_telemetry
+    batch_size = (@all_items.to_f / @parallel_jobs).ceil
+
+    Parallel.map(0...@parallel_jobs, in_processes: @parallel_jobs) do |jobid|
+      errors = {}
+      validations = {}
+
+      offset = batch_size * jobid
+      ids = @model.order(:id).limit(batch_size).offset(offset).pluck(:id)
+
+      ids.each_slice(1000) do |slice|
+        @model.where(id: slice).order(:id).each do |s|
+          errors_for_record, validations_for_record = load_and_validate_item(s)
+          errors.merge!(errors_for_record)
+          validations.merge!(validations_for_record)
+        end
+      end
+
+      {
+        errors: errors,
+        validations: validations,
+        observations: EMPTY_OBSERVATIONS
+      }
+    end
+  end
+
+  def validate_items_with_telemetry
     batch_size = (@all_items.to_f / @parallel_jobs).ceil
 
     Parallel.map(0...@parallel_jobs, in_processes: @parallel_jobs) do |jobid|
@@ -278,7 +320,7 @@ class MuscatCheckup
 
       ids.each_slice(1000) do |slice|
         @model.where(id: slice).order(:id).each do |s|
-          result = load_and_validate_item(s, telemetry)
+          result = load_and_validate_item_with_telemetry(s, telemetry)
           errors.merge!(result.errors)
           validations.merge!(result.validations)
           telemetry.record(s, result.findings)
@@ -294,6 +336,29 @@ class MuscatCheckup
   end
 
   def validate_folder
+    return validate_folder_with_telemetry if telemetry_enabled?
+    validate_folder_without_telemetry
+  end
+
+  def validate_folder_without_telemetry
+    errors = {}
+    validations = {}
+
+    @folder.folder_items.each do |fi|
+      next if !fi.item
+      s = fi.item
+
+      errors_for_record, validations_for_record = load_and_validate_item(s)
+      errors.merge!(errors_for_record)
+      validations.merge!(validations_for_record)
+
+      s = nil
+    end
+
+    [{ errors: errors, validations: validations, observations: EMPTY_OBSERVATIONS }]
+  end
+
+  def validate_folder_with_telemetry
     errors = {}
     validations = {}
     telemetry = build_telemetry_worker
@@ -302,20 +367,35 @@ class MuscatCheckup
       next if !fi.item
       s = fi.item
 
-      result = load_and_validate_item(s, telemetry)
+      result = load_and_validate_item_with_telemetry(s, telemetry)
       errors.merge!(result.errors)
       validations.merge!(result.validations)
       telemetry.record(s, result.findings)
-      
+
       s = nil
     end
-      
+
     [{ errors: errors, validations: validations, observations: telemetry.observations }]
   end
 
-  def validate_record(record, telemetry)
+  def validate_record(record)
+    validator = MarcValidator.new(record, nil, false, @debug_logger, @validation_exclusions)
+    run_record_validations(validator)
+    validator.get_errors
+  end
+
+  def validate_record_with_telemetry(record, telemetry)
     # if something is wrong, let the validator throw and it will be caught by the logger
     validator = MarcValidator.new(record, nil, false, @debug_logger, @validation_exclusions, collect_findings: telemetry.collect_findings?)
+    run_record_validations(validator)
+    RecordCheckupResult.new(
+      errors: {},
+      validations: validator.get_errors,
+      findings: validator.get_findings
+    )
+  end
+
+  def run_record_validations(validator)
     validator.validate_tags               if !@skip_validation
     validator.validate_dates              if !@skip_dates
     validator.validate_links              if !@skip_links
@@ -328,11 +408,6 @@ class MuscatCheckup
     validator.validate_work_status        if !@skip_validate_work_status
     validator.validate_template_harmony   if !@skip_parent_check
     validator.validate_person_codes       if !@skip_validate_person_codes
-    RecordCheckupResult.new(
-      errors: {},
-      validations: validator.get_errors,
-      findings: validator.get_findings
-    )
   end
   
   def postprocess_results(validations, limit_unknown_tags: true, unknown_tag_limit: UNKNOWN_TAG_LIMIT)
@@ -398,7 +473,11 @@ class MuscatCheckup
   end
 
   def build_telemetry_worker
-    @telemetry_worker_class.new(@observability)
+    TelemetryWorker.new(@observability)
+  end
+
+  def telemetry_enabled?
+    @telemetry_enabled
   end
 
 end

--- a/lib/muscat_checkup.rb
+++ b/lib/muscat_checkup.rb
@@ -1,6 +1,98 @@
 require 'stringio'
 require 'set'
 
+class MuscatCheckupResult
+  attr_reader :errors, :validations, :findings
+
+  def initialize(errors:, validations:, findings: [])
+    @errors = errors
+    @validations = validations
+    @findings = findings
+  end
+end
+
+class TelemetryNullWorker
+  def initialize(*)
+    @observations = {
+      records_scanned: 0,
+      records_with_findings: 0,
+      findings: Hash.new(0)
+    }
+  end
+
+  def collect_findings?
+    false
+  end
+
+  def technical_findings(output:, exception:, phase:)
+    []
+  end
+
+  def record(record, findings)
+  end
+
+  attr_reader :observations
+end
+
+class TelemetryWorker < TelemetryNullWorker
+  def initialize(observability)
+    super()
+    @event_stream = ValidationObservability::EventStream.new(**observability)
+  end
+
+  def collect_findings?
+    true
+  end
+
+  def technical_findings(output:, exception:, phase:)
+    findings = []
+
+    if output.strip.present?
+      category = exception ? "record_exception_#{phase}" : "record_error"
+      findings << technical_finding(category, output.strip)
+    end
+
+    if exception
+      findings << technical_finding("record_exception_#{phase}", exception.message)
+    end
+
+    findings
+  end
+
+  def record(record, findings)
+    @observations[:records_scanned] += 1
+    return if findings.empty?
+
+    record_type = print_record_type(record)
+    @event_stream.validation_message(
+      record_id: record.id,
+      record_type: record_type,
+      findings: findings
+    )
+
+    @observations[:records_with_findings] += 1
+    findings.each do |finding|
+      @observations[:findings][[record_type, finding[:category]]] += 1
+    end
+  end
+
+  private
+
+  def print_record_type(record)
+    return "none" unless record.respond_to?(:get_record_type)
+    record.get_record_type&.to_s || "none"
+  end
+
+  def technical_finding(category, message)
+    {
+      tag: "no_tag",
+      subtag: "no_subtag",
+      message: message.to_s,
+      category: category
+    }
+  end
+end
+
 class MuscatCheckup  
 
   # It was 10, but now we should have exclusions
@@ -15,6 +107,7 @@ class MuscatCheckup
 
     @debug_logger = options[:logger]
     @observability = options[:observability]
+    @telemetry_worker_class = @observability.present? ? TelemetryWorker : TelemetryNullWorker
 
     @skip_validation            = options[:skip_validation] == true
     @skip_dates                 = options[:skip_dates] == true
@@ -54,36 +147,33 @@ class MuscatCheckup
     # Extract and separate the errors and validations
     total_errors = {}
     total_validations = {}
-    observations = { records_scanned: 0, records_with_findings: 0, findings: Hash.new(0) } if telemetry_enabled?
+    observations = { records_scanned: 0, records_with_findings: 0, findings: Hash.new(0) }
     results.each do |r|
       total_errors.merge!(r[:errors])
       total_validations.merge!(r[:validations])
-      if telemetry_enabled?
-        observations[:records_scanned] += r[:records_scanned]
-        observations[:records_with_findings] += r[:records_with_findings]
-        r[:findings].each { |key, count| observations[:findings][key] += count }
-      end
+      observations[:records_scanned] += r[:observations][:records_scanned]
+      observations[:records_with_findings] += r[:observations][:records_with_findings]
+      r[:observations][:findings].each { |key, count| observations[:findings][key] += count }
     end
         
     filtered_validations, foreign_tag_errors, unknown_tags = postprocess_results(total_validations, limit_unknown_tags: limit_unknown_tags)
-    return total_errors, filtered_validations, foreign_tag_errors, unknown_tags, observations if telemetry_enabled?
-    return total_errors, filtered_validations, foreign_tag_errors, unknown_tags
+    [total_errors, filtered_validations, foreign_tag_errors, unknown_tags, observations]
 
   end
   
   private
 
-  def load_and_validate_item(s)
+  def load_and_validate_item(s, telemetry)
     errors = {}
     validations = {}
-    findings = [] if telemetry_enabled?
+    findings = []
 
     phase = :load
 
     result, output, exception = capture_stdout_and_stderr do
       #s.marc.load_source(true)
       phase = :validate
-      validate_record(s)
+      validate_record(s, telemetry)
     end
 
     unless output.strip.empty?
@@ -95,20 +185,24 @@ class MuscatCheckup
       append_exception(errors, s.id, exception)
       @debug_logger.error("[#{phase}] #{exception.backtrace.first(2).join("\n")}") if @debug_logger
       puts "[#{phase}] #{exception.backtrace.first(2).join("\n")}" # Also print the message on the stdout sink 
-    elsif result.present? && telemetry_enabled?
-      validations[s.id] = result[:errors] if result[:errors].present?
-      findings.concat(result[:findings])
     elsif result.present?
-      validations[s.id] = result
+      validations[s.id] = result.validations if result.validations.present?
+      findings.concat(result.findings)
     end
 
-    if telemetry_enabled? && output.strip.present?
-      findings << technical_finding(exception ? "record_exception_#{phase}" : "record_error", output.strip)
-    end
-    findings << technical_finding("record_exception_#{phase}", exception.message) if telemetry_enabled? && exception
+    findings.concat(
+      telemetry.technical_findings(
+        output: output,
+        exception: exception,
+        phase: phase
+      )
+    )
 
-    return [errors, validations, findings] if telemetry_enabled?
-    [errors, validations]
+    MuscatCheckupResult.new(
+      errors: errors,
+      validations: validations,
+      findings: findings
+    )
   end
 
   def capture_stdout_and_stderr
@@ -159,95 +253,51 @@ class MuscatCheckup
     Parallel.map(0...@parallel_jobs, in_processes: @parallel_jobs) do |jobid|
       errors = {}
       validations = {}
-      records_scanned = 0 if telemetry_enabled?
-      records_with_findings = 0 if telemetry_enabled?
-      findings_by_category = Hash.new(0) if telemetry_enabled?
-      event_stream = observability_event_stream if telemetry_enabled?
+      telemetry = build_telemetry_worker
 
       offset = batch_size * jobid
-=begin
-      @model.order(:id).limit(batch_size).offset(offset).select(:id).each do |sid|
-        s = @model.find(sid.id)
-        
-        e, v = load_and_validate_item(s)
-        errors.merge!(e)
-        validations.merge!(v)
-        
-        s = nil
-      end
-=end
       ids = @model.order(:id).limit(batch_size).offset(offset).pluck(:id)
 
       ids.each_slice(1000) do |slice|
         @model.where(id: slice).order(:id).each do |s|
-          result = load_and_validate_item(s)
-          e, v = result
-          errors.merge!(e)
-          validations.merge!(v)
-          if telemetry_enabled?
-            findings = result[2]
-            records_scanned += 1
-            record_type = print_record_type(s)
-            if findings.any?
-              event_stream.validation_message(record_id: s.id, record_type: record_type, findings: findings)
-              records_with_findings += 1
-              findings.each { |finding| findings_by_category[[record_type, finding[:category]]] += 1 }
-            end
-          end
+          result = load_and_validate_item(s, telemetry)
+          errors.merge!(result.errors)
+          validations.merge!(result.validations)
+          telemetry.record(s, result.findings)
         end
       end
 
-      if telemetry_enabled?
-        {
-          errors: errors,
-          validations: validations,
-          records_scanned: records_scanned,
-          records_with_findings: records_with_findings,
-          findings: findings_by_category
-        }
-      else
-        { errors: errors, validations: validations }
-      end
+      {
+        errors: errors,
+        validations: validations,
+        observations: telemetry.observations
+      }
     end
   end
 
   def validate_folder
     errors = {}
     validations = {}
-    records_scanned = 0 if telemetry_enabled?
-    records_with_findings = 0 if telemetry_enabled?
-    findings_by_category = Hash.new(0) if telemetry_enabled?
-    event_stream = observability_event_stream if telemetry_enabled?
+    telemetry = build_telemetry_worker
 
     @folder.folder_items.each do |fi|
       next if !fi.item
       s = fi.item
 
-      result = load_and_validate_item(s)
-      e, v = result
-      errors.merge!(e)
-      validations.merge!(v)
-      if telemetry_enabled?
-        findings = result[2]
-        records_scanned += 1
-        record_type = print_record_type(s)
-        if findings.any?
-          event_stream.validation_message(record_id: s.id, record_type: record_type, findings: findings)
-          records_with_findings += 1
-          findings.each { |finding| findings_by_category[[record_type, finding[:category]]] += 1 }
-        end
-      end
+      result = load_and_validate_item(s, telemetry)
+      errors.merge!(result.errors)
+      validations.merge!(result.validations)
+      telemetry.record(s, result.findings)
       
       s = nil
     end
       
-    return [{ errors: errors, validations: validations, records_scanned: records_scanned, records_with_findings: records_with_findings, findings: findings_by_category }] if telemetry_enabled?
-    [{ errors: errors, validations: validations }]
+    [{ errors: errors, validations: validations, observations: telemetry.observations }]
   end
 
-  def validate_record(record)
+  def validate_record(record, telemetry)
     # if something is wrong, let the validator throw and it will be caught by the logger
-    validator = MarcValidator.new(record, nil, false, @debug_logger, @validation_exclusions, collect_findings: telemetry_enabled?)
+    validator = MarcValidator.new(record, nil, false, @debug_logger, @validation_exclusions, collect_findings: telemetry.collect_findings?)
     validator.validate_tags               if !@skip_validation
     validator.validate_dates              if !@skip_dates
     validator.validate_links              if !@skip_links
@@ -260,8 +310,11 @@ class MuscatCheckup
     validator.validate_work_status        if !@skip_validate_work_status
     validator.validate_template_harmony   if !@skip_parent_check
     validator.validate_person_codes       if !@skip_validate_person_codes
-    return { errors: validator.get_errors, findings: validator.get_findings } if telemetry_enabled?
-    validator.get_errors
+    MuscatCheckupResult.new(
+      errors: {},
+      validations: validator.get_errors,
+      findings: validator.get_findings
+    )
   end
   
   def postprocess_results(validations, limit_unknown_tags: true, unknown_tag_limit: UNKNOWN_TAG_LIMIT)
@@ -326,17 +379,8 @@ class MuscatCheckup
     item.get_record_type&.to_s || "none"
   end
 
-  def technical_finding(category, message)
-    { tag: "no_tag", subtag: "no_subtag", message: message.to_s, category: category }
-  end
-
-  def observability_event_stream
-    return nil unless @observability
-    ValidationObservability::EventStream.new(**@observability)
-  end
-
-  def telemetry_enabled?
-    @observability.present?
+  def build_telemetry_worker
+    @telemetry_worker_class.new(@observability)
   end
 
 end

--- a/lib/muscat_checkup.rb
+++ b/lib/muscat_checkup.rb
@@ -14,6 +14,7 @@ class MuscatCheckup
     @folder = options[:folder]
 
     @debug_logger = options[:logger]
+    @observability = options[:observability]
 
     @skip_validation            = options[:skip_validation] == true
     @skip_dates                 = options[:skip_dates] == true
@@ -53,12 +54,19 @@ class MuscatCheckup
     # Extract and separate the errors and validations
     total_errors = {}
     total_validations = {}
+    observations = { records_scanned: 0, records_with_findings: 0, findings: Hash.new(0) } if telemetry_enabled?
     results.each do |r|
       total_errors.merge!(r[:errors])
       total_validations.merge!(r[:validations])
+      if telemetry_enabled?
+        observations[:records_scanned] += r[:records_scanned]
+        observations[:records_with_findings] += r[:records_with_findings]
+        r[:findings].each { |key, count| observations[:findings][key] += count }
+      end
     end
         
     filtered_validations, foreign_tag_errors, unknown_tags = postprocess_results(total_validations, limit_unknown_tags: limit_unknown_tags)
+    return total_errors, filtered_validations, foreign_tag_errors, unknown_tags, observations if telemetry_enabled?
     return total_errors, filtered_validations, foreign_tag_errors, unknown_tags
 
   end
@@ -68,6 +76,7 @@ class MuscatCheckup
   def load_and_validate_item(s)
     errors = {}
     validations = {}
+    findings = [] if telemetry_enabled?
 
     phase = :load
 
@@ -86,10 +95,19 @@ class MuscatCheckup
       append_exception(errors, s.id, exception)
       @debug_logger.error("[#{phase}] #{exception.backtrace.first(2).join("\n")}") if @debug_logger
       puts "[#{phase}] #{exception.backtrace.first(2).join("\n")}" # Also print the message on the stdout sink 
+    elsif result.present? && telemetry_enabled?
+      validations[s.id] = result[:errors] if result[:errors].present?
+      findings.concat(result[:findings])
     elsif result.present?
       validations[s.id] = result
     end
 
+    if telemetry_enabled? && output.strip.present?
+      findings << technical_finding(exception ? "record_exception_#{phase}" : "record_error", output.strip)
+    end
+    findings << technical_finding("record_exception_#{phase}", exception.message) if telemetry_enabled? && exception
+
+    return [errors, validations, findings] if telemetry_enabled?
     [errors, validations]
   end
 
@@ -141,6 +159,10 @@ class MuscatCheckup
     Parallel.map(0...@parallel_jobs, in_processes: @parallel_jobs) do |jobid|
       errors = {}
       validations = {}
+      records_scanned = 0 if telemetry_enabled?
+      records_with_findings = 0 if telemetry_enabled?
+      findings_by_category = Hash.new(0) if telemetry_enabled?
+      event_stream = observability_event_stream if telemetry_enabled?
 
       offset = batch_size * jobid
 =begin
@@ -158,37 +180,74 @@ class MuscatCheckup
 
       ids.each_slice(1000) do |slice|
         @model.where(id: slice).order(:id).each do |s|
-          e, v = load_and_validate_item(s)
+          result = load_and_validate_item(s)
+          e, v = result
           errors.merge!(e)
           validations.merge!(v)
+          if telemetry_enabled?
+            findings = result[2]
+            records_scanned += 1
+            record_type = print_record_type(s)
+            if findings.any?
+              event_stream.validation_message(record_id: s.id, record_type: record_type, findings: findings)
+              records_with_findings += 1
+              findings.each { |finding| findings_by_category[[record_type, finding[:category]]] += 1 }
+            end
+          end
         end
       end
 
-      { errors: errors, validations: validations }
+      if telemetry_enabled?
+        {
+          errors: errors,
+          validations: validations,
+          records_scanned: records_scanned,
+          records_with_findings: records_with_findings,
+          findings: findings_by_category
+        }
+      else
+        { errors: errors, validations: validations }
+      end
     end
   end
 
   def validate_folder
     errors = {}
     validations = {}
+    records_scanned = 0 if telemetry_enabled?
+    records_with_findings = 0 if telemetry_enabled?
+    findings_by_category = Hash.new(0) if telemetry_enabled?
+    event_stream = observability_event_stream if telemetry_enabled?
 
     @folder.folder_items.each do |fi|
       next if !fi.item
       s = fi.item
 
-      e, v = load_and_validate_item(s)
+      result = load_and_validate_item(s)
+      e, v = result
       errors.merge!(e)
       validations.merge!(v)
+      if telemetry_enabled?
+        findings = result[2]
+        records_scanned += 1
+        record_type = print_record_type(s)
+        if findings.any?
+          event_stream.validation_message(record_id: s.id, record_type: record_type, findings: findings)
+          records_with_findings += 1
+          findings.each { |finding| findings_by_category[[record_type, finding[:category]]] += 1 }
+        end
+      end
       
       s = nil
     end
       
-    [{errors: errors, validations: validations}]
+    return [{ errors: errors, validations: validations, records_scanned: records_scanned, records_with_findings: records_with_findings, findings: findings_by_category }] if telemetry_enabled?
+    [{ errors: errors, validations: validations }]
   end
 
   def validate_record(record)
     # if something is wrong, let the validator throw and it will be caught by the logger
-    validator = MarcValidator.new(record, nil, false, @debug_logger, @validation_exclusions)
+    validator = MarcValidator.new(record, nil, false, @debug_logger, @validation_exclusions, collect_findings: telemetry_enabled?)
     validator.validate_tags               if !@skip_validation
     validator.validate_dates              if !@skip_dates
     validator.validate_links              if !@skip_links
@@ -201,7 +260,8 @@ class MuscatCheckup
     validator.validate_work_status        if !@skip_validate_work_status
     validator.validate_template_harmony   if !@skip_parent_check
     validator.validate_person_codes       if !@skip_validate_person_codes
-    return validator.get_errors
+    return { errors: validator.get_errors, findings: validator.get_findings } if telemetry_enabled?
+    validator.get_errors
   end
   
   def postprocess_results(validations, limit_unknown_tags: true, unknown_tag_limit: UNKNOWN_TAG_LIMIT)
@@ -264,6 +324,19 @@ class MuscatCheckup
   def print_record_type(item)
     return "none" unless item.respond_to?(:get_record_type)
     item.get_record_type&.to_s || "none"
+  end
+
+  def technical_finding(category, message)
+    { tag: "no_tag", subtag: "no_subtag", message: message.to_s, category: category }
+  end
+
+  def observability_event_stream
+    return nil unless @observability
+    ValidationObservability::EventStream.new(**@observability)
+  end
+
+  def telemetry_enabled?
+    @observability.present?
   end
 
 end

--- a/lib/muscat_checkup.rb
+++ b/lib/muscat_checkup.rb
@@ -2,9 +2,21 @@ require 'stringio'
 require 'set'
 
 class MuscatCheckupResult
+  attr_reader :errors, :validations, :foreign_tag_errors, :unknown_tags, :observations
+
+  def initialize(errors:, validations:, foreign_tag_errors:, unknown_tags:, observations:)
+    @errors = errors
+    @validations = validations
+    @foreign_tag_errors = foreign_tag_errors
+    @unknown_tags = unknown_tags
+    @observations = observations
+  end
+end
+
+class RecordCheckupResult
   attr_reader :errors, :validations, :findings
 
-  def initialize(errors:, validations:, findings: [])
+  def initialize(errors:, validations:, findings:)
     @errors = errors
     @validations = validations
     @findings = findings
@@ -157,7 +169,13 @@ class MuscatCheckup
     end
         
     filtered_validations, foreign_tag_errors, unknown_tags = postprocess_results(total_validations, limit_unknown_tags: limit_unknown_tags)
-    [total_errors, filtered_validations, foreign_tag_errors, unknown_tags, observations]
+    MuscatCheckupResult.new(
+      errors: total_errors,
+      validations: filtered_validations,
+      foreign_tag_errors: foreign_tag_errors,
+      unknown_tags: unknown_tags,
+      observations: observations
+    )
 
   end
   
@@ -198,7 +216,7 @@ class MuscatCheckup
       )
     )
 
-    MuscatCheckupResult.new(
+    RecordCheckupResult.new(
       errors: errors,
       validations: validations,
       findings: findings
@@ -310,7 +328,7 @@ class MuscatCheckup
     validator.validate_work_status        if !@skip_validate_work_status
     validator.validate_template_harmony   if !@skip_parent_check
     validator.validate_person_codes       if !@skip_validate_person_codes
-    MuscatCheckupResult.new(
+    RecordCheckupResult.new(
       errors: {},
       validations: validator.get_errors,
       findings: validator.get_findings

--- a/lib/validation_observability.rb
+++ b/lib/validation_observability.rb
@@ -1,0 +1,180 @@
+require "json"
+require "pathname"
+require "securerandom"
+require "tempfile"
+require "time"
+
+# Writes monitoring artifacts for complete, scheduled Muscat checkups. It is
+# deliberately file based: checkup jobs are short-lived processes, while Alloy
+# can reliably collect durable local files.
+class ValidationObservability
+  DEFAULT_PROMETHEUS_TEXTFILE = Rails.root.join("log", "validation_metrics.prom").freeze
+  DEFAULT_LOKI_LOG = Rails.root.join("log", "validation_observability.jsonl").freeze
+
+  def initialize(prometheus_textfile: ENV.fetch("MUSCAT_VALIDATION_PROMETHEUS_TEXTFILE", DEFAULT_PROMETHEUS_TEXTFILE.to_s),
+                 loki_log: ENV.fetch("MUSCAT_VALIDATION_LOKI_LOG", DEFAULT_LOKI_LOG.to_s))
+    @prometheus_textfile = Pathname.new(prometheus_textfile)
+    @loki_log = Pathname.new(loki_log)
+  end
+
+  def start_run!(model:, started_at:)
+    stream = EventStream.new(loki_log: @loki_log, run_id: SecureRandom.uuid, model: model.to_s)
+    stream.run_started(started_at)
+    stream
+  rescue StandardError => e
+    Rails.logger.error("validation_observability_export_failed model=#{model} error=#{e.class}: #{e.message}")
+    raise
+  end
+
+  def complete!(stream:, started_at:, completed_at:, observations:)
+    summary = summarize(observations)
+    write_prometheus_textfile!(prometheus_path(stream.model), render_prometheus(stream.model, started_at, completed_at, summary))
+    stream.run_completed(completed_at, summary.merge(duration_seconds: completed_at - started_at))
+  rescue StandardError => e
+    Rails.logger.error("validation_observability_export_failed model=#{stream.model} error=#{e.class}: #{e.message}")
+    raise
+  end
+
+  private
+
+  def summarize(observations)
+    findings = Hash.new(0)
+    observations.fetch(:findings, {}).each do |(record_type, category), count|
+      findings[[normalise(record_type), normalise(category)]] += count
+    end
+
+    {
+      records_scanned: observations.fetch(:records_scanned, 0),
+      records_with_findings: observations.fetch(:records_with_findings, 0),
+      findings: findings
+    }
+  end
+
+  def write_prometheus_textfile!(path, contents)
+    Tempfile.create(["validation_metrics", ".prom"], path.dirname.to_s) do |file|
+      file.write(contents)
+      file.flush
+      file.fsync
+      File.rename(file.path, path)
+    end
+  end
+
+  def render_prometheus(model_name, started_at, completed_at, summary)
+    labels = "model=\"#{escape_label(model_name)}\""
+    lines = [
+      "# HELP muscat_validation_last_run_completed_timestamp_seconds Unix timestamp of the latest completed scheduled validation run.",
+      "# TYPE muscat_validation_last_run_completed_timestamp_seconds gauge",
+      "muscat_validation_last_run_completed_timestamp_seconds{#{labels}} #{completed_at.to_f}",
+      "# HELP muscat_validation_last_run_successful_timestamp_seconds Unix timestamp of the latest successfully exported scheduled validation run.",
+      "# TYPE muscat_validation_last_run_successful_timestamp_seconds gauge",
+      "muscat_validation_last_run_successful_timestamp_seconds{#{labels}} #{completed_at.to_f}",
+      "# HELP muscat_validation_last_run_duration_seconds Duration of the latest scheduled validation run.",
+      "# TYPE muscat_validation_last_run_duration_seconds gauge",
+      "muscat_validation_last_run_duration_seconds{#{labels}} #{completed_at - started_at}",
+      "# HELP muscat_validation_last_run_records_scanned Records scanned during the latest scheduled validation run.",
+      "# TYPE muscat_validation_last_run_records_scanned gauge",
+      "muscat_validation_last_run_records_scanned{#{labels}} #{summary[:records_scanned]}",
+      "# HELP muscat_validation_last_run_records_with_findings Records with one or more validation findings in the latest run.",
+      "# TYPE muscat_validation_last_run_records_with_findings gauge",
+      "muscat_validation_last_run_records_with_findings{#{labels}} #{summary[:records_with_findings]}",
+      "# HELP muscat_validation_last_run_findings Validation findings in the latest run, grouped by stable category and record type.",
+      "# TYPE muscat_validation_last_run_findings gauge"
+    ]
+
+    summary[:findings].sort.each do |(record_type, category), count|
+      finding_labels = [labels, "record_type=\"#{escape_label(record_type)}\"", "category=\"#{escape_label(category)}\""].join(",")
+      lines << "muscat_validation_last_run_findings{#{finding_labels}} #{count}"
+    end
+    lines.join("\n") + "\n"
+  end
+
+  # Separate model files avoid one scheduled job removing the most recent
+  # metrics written by the other model checkups.
+  def prometheus_path(model_name)
+    base = @prometheus_textfile.to_s
+    base = base.delete_suffix(".prom")
+    Pathname.new("#{base}_#{underscore(model_name)}.prom")
+  end
+
+  def underscore(value)
+    value.to_s.gsub(/([a-z\d])([A-Z])/, "\\1_\\2").downcase
+  end
+
+  def escape_label(value)
+    value.to_s.gsub("\\", "\\\\").gsub("\n", "\\n").gsub("\"", "\\\"")
+  end
+
+  def normalise(value)
+    value.to_s.empty? ? "unknown" : value.to_s
+  end
+
+  class EventStream
+    attr_reader :model, :run_id
+
+    def initialize(loki_log:, run_id:, model:)
+      @loki_log = Pathname.new(loki_log)
+      @run_id = run_id
+      @model = model
+    end
+
+    def metadata
+      { loki_log: @loki_log.to_s, run_id: @run_id, model: @model }
+    end
+
+    def run_started(at)
+      append(event: "validation_run_started", timestamp: timestamp(at))
+    end
+
+    def validation_message(record_id:, record_type:, findings:)
+      append(
+        event: "validation_message",
+        timestamp: timestamp(Time.now),
+        record_id: record_id,
+        record_type: normalise(record_type),
+        findings: findings
+      )
+    end
+
+    def run_completed(at, summary)
+      append(
+        event: "validation_run_completed",
+        timestamp: timestamp(at),
+        duration_seconds: summary.fetch(:duration_seconds),
+        records_scanned: summary.fetch(:records_scanned),
+        records_with_findings: summary.fetch(:records_with_findings)
+      )
+    end
+
+    def run_failed(error, at = Time.now)
+      append(
+        event: "validation_run_failed",
+        timestamp: timestamp(at),
+        error_class: error.class.to_s,
+        error_message: error.message.to_s
+      )
+    end
+
+    private
+
+    def append(payload)
+      event = { workflow: "scheduled_checkup", model: @model, run_id: @run_id }.merge(payload)
+
+      File.open(@loki_log, "a") do |file|
+        file.flock(File::LOCK_EX)
+        file.write(JSON.generate(event))
+        file.write("\n")
+        file.flush
+      ensure
+        file.flock(File::LOCK_UN) if file
+      end
+    end
+
+    def normalise(value)
+      value.to_s.empty? ? "unknown" : value.to_s
+    end
+
+    def timestamp(value)
+      value.utc.iso8601(3)
+    end
+  end
+end

--- a/spec/lib/muscat_checkup_spec.rb
+++ b/spec/lib/muscat_checkup_spec.rb
@@ -1,0 +1,151 @@
+ENV["RAILS_ENV"] ||= "test"
+require File.expand_path("../../config/environment", __dir__)
+require Rails.root.join("lib", "muscat_checkup")
+
+RSpec.describe MuscatCheckupResult do
+  it "exposes the complete checkup result" do
+    result = described_class.new(
+      errors: { 1 => "failed" },
+      validations: { 1 => { "100" => {} } },
+      foreign_tag_errors: ["100a old val"],
+      unknown_tags: { "999-a" => { count: 1, items: [1] } },
+      observations: { records_scanned: 1 }
+    )
+
+    expect(result.errors).to eq(1 => "failed")
+    expect(result.validations).to eq(1 => { "100" => {} })
+    expect(result.foreign_tag_errors).to eq(["100a old val"])
+    expect(result.unknown_tags).to eq("999-a" => { count: 1, items: [1] })
+    expect(result.observations).to eq(records_scanned: 1)
+  end
+end
+
+RSpec.describe RecordCheckupResult do
+  it "exposes one record's errors, validations, and findings" do
+    result = described_class.new(
+      errors: { 1 => "failed" },
+      validations: { 1 => { "100" => {} } },
+      findings: [{ category: "validation_error" }]
+    )
+
+    expect(result.errors).to eq(1 => "failed")
+    expect(result.validations).to eq(1 => { "100" => {} })
+    expect(result.findings).to eq([{ category: "validation_error" }])
+  end
+end
+
+RSpec.describe MuscatCheckup do
+  it "returns a consistent result when telemetry is disabled" do
+    model = Class.new do
+      def self.count
+        0
+      end
+    end
+    folder = Struct.new(:folder_items).new([])
+
+    result = described_class.new(model: model, folder: folder).validate_parallel
+
+    expect(result).to be_a(MuscatCheckupResult)
+    expect(result.errors).to eq({})
+    expect(result.validations).to eq({})
+    expect(result.foreign_tag_errors).to eq([])
+    expect(result.unknown_tags).to eq({})
+    expect(result.observations).to eq(
+      records_scanned: 0,
+      records_with_findings: 0,
+      findings: {}
+    )
+  end
+end
+
+RSpec.describe TelemetryNullWorker do
+  subject(:worker) { described_class.new(nil) }
+
+  it "implements telemetry operations without collecting anything" do
+    worker.record(double("record"), [{ category: "validation_error" }])
+
+    expect(worker).not_to be_collect_findings
+    expect(worker.technical_findings(output: "error", exception: StandardError.new("failed"), phase: :validate)).to eq([])
+    expect(worker.observations).to eq(
+      records_scanned: 0,
+      records_with_findings: 0,
+      findings: {}
+    )
+  end
+end
+
+RSpec.describe TelemetryWorker do
+  subject(:worker) { described_class.new(observability) }
+
+  let(:event_stream) { instance_double(ValidationObservability::EventStream) }
+  let(:observability) do
+    {
+      loki_log: "/tmp/validation.jsonl",
+      run_id: "run-id",
+      model: "Source"
+    }
+  end
+  let(:record) do
+    Struct.new(:id) do
+      def get_record_type
+        :manuscript
+      end
+    end.new(42)
+  end
+
+  before do
+    allow(ValidationObservability::EventStream).to receive(:new).and_return(event_stream)
+  end
+
+  it "streams findings and updates its observations" do
+    findings = [{ tag: "100", subtag: "a", message: "Invalid", category: "validation_error" }]
+    emitted_event = nil
+
+    allow(event_stream).to receive(:validation_message) do |event|
+      emitted_event = event
+    end
+
+    worker.record(record, findings)
+
+    expect(emitted_event).to eq(
+      record_id: 42,
+      record_type: "manuscript",
+      findings: findings
+    )
+    expect(worker).to be_collect_findings
+    expect(worker.observations).to eq(
+      records_scanned: 1,
+      records_with_findings: 1,
+      findings: { ["manuscript", "validation_error"] => 1 }
+    )
+  end
+
+  it "counts clean records without writing an event" do
+    expect(event_stream).not_to receive(:validation_message)
+
+    worker.record(record, [])
+
+    expect(worker.observations).to include(records_scanned: 1, records_with_findings: 0)
+  end
+
+  it "turns captured output and exceptions into technical findings" do
+    exception = StandardError.new("validation failed")
+
+    expect(worker.technical_findings(output: "diagnostic", exception: exception, phase: :validate)).to eq(
+      [
+        {
+          tag: "no_tag",
+          subtag: "no_subtag",
+          message: "diagnostic",
+          category: "record_exception_validate"
+        },
+        {
+          tag: "no_tag",
+          subtag: "no_subtag",
+          message: "validation failed",
+          category: "record_exception_validate"
+        }
+      ]
+    )
+  end
+end

--- a/spec/lib/muscat_checkup_spec.rb
+++ b/spec/lib/muscat_checkup_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe MuscatCheckup do
     end
     folder = Struct.new(:folder_items).new([])
 
+    expect(TelemetryWorker).not_to receive(:new)
     result = described_class.new(model: model, folder: folder).validate_parallel
 
     expect(result).to be_a(MuscatCheckupResult)
@@ -56,21 +57,21 @@ RSpec.describe MuscatCheckup do
       findings: {}
     )
   end
-end
 
-RSpec.describe TelemetryNullWorker do
-  subject(:worker) { described_class.new(nil) }
+  it "does not build a telemetry result for a normal record validation" do
+    model = Class.new do
+      def self.count
+        0
+      end
+    end
+    record = Struct.new(:id).new(42)
+    checkup = described_class.new(model: model)
+    validation = { "100" => { "a" => ["Invalid"] } }
 
-  it "implements telemetry operations without collecting anything" do
-    worker.record(double("record"), [{ category: "validation_error" }])
+    allow(checkup).to receive(:validate_record).with(record).and_return(validation)
+    expect(RecordCheckupResult).not_to receive(:new)
 
-    expect(worker).not_to be_collect_findings
-    expect(worker.technical_findings(output: "error", exception: StandardError.new("failed"), phase: :validate)).to eq([])
-    expect(worker.observations).to eq(
-      records_scanned: 0,
-      records_with_findings: 0,
-      findings: {}
-    )
+    expect(checkup.send(:load_and_validate_item, record)).to eq([{}, { 42 => validation }])
   end
 end
 


### PR DESCRIPTION
These changes adds prometheus metrics and loki JSONL logs for export into an observability stack.

The output is "opt-in", where the 'telemetry' option has to be explicitly set, e.g.,: 

```
$ ./bin/muscat_execute_job MuscatCheckupReportJob production Person --telemetry
```

This will cause a number of new files to be produced. Each validation run will produce a .prom file, e.g.,: `log/validation_metrics_person.prom`. These files contain counters and datetime stamps, giving us some overall measures of individual runs. For example:

```
muscat_validation_last_run_completed_timestamp_seconds{model="Person"} 1787745261.338274
muscat_validation_last_run_records_scanned{model="Person"} 163151
muscat_validation_last_run_records_with_findings{model="Person"} 5081
muscat_validation_last_run_findings{model="Person",record_type="none",category="validation_error"} 5086
muscat_validation_last_run_findings{model="Person",record_type="none",category="link_error"} 1
```

(one record can have several "findings") 

The second output is a full jsonl file for all the logs: 

```
{"workflow":"scheduled_checkup","model":"Person","run_id":"a09b4ef6-8654-4420-9797-ccbbf26fe2d7","event":"validation_message","timestamp":"2026-08-26T15:05:03.303Z","record_id":41001806,"record_type":"none","findings":[{"tag":"042","subtag":"no_subtag","message":"A value in this field is mandatory","category":"validation_error"}]}
```

etc. This contains all the events from the error reports, and can be sliced in different ways once ingested in the Loki system.

The system should still keep all the old functionality in both telemetry and non-telemetry modes. 

All of these files can then be shipped off to our monitoring system through the "Alloy" log shipper we have installed on the Muscat server. 